### PR TITLE
Rendi raggiungibile il consenso alla telemetria e correggi il provider

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -9,25 +9,40 @@ If you installed via the Claude Code marketplace
 of each session until you've made a decision. The reminder only informs you.
 It never blocks a session or prompts by itself.
 
+If `DO_NOT_TRACK` is set to any non-empty value other than `0`, it is a
+runtime privacy override: Sando does not prompt, collect, queue, or upload
+telemetry, even when the local config says `enabled: true`. Sando does not
+rewrite that config; unset `DO_NOT_TRACK` to use the saved setting again.
+
 ## What's collected
 
-Once a day, Sando buckets that day's counts and sends one row per event
-type it saw:
+Once a day, Sando buckets that day's counts and sends only these event shapes:
 
-- `hook`: tool-call count, redaction count, capped-output count, bytes
-  saved, all bucketed (`zero`, `one`, `2_to_5`, `6_to_20`, `gt_20`; byte
-  ranges like `16_to_64k`), per host (`claude`/`codex`) and mode
-  (`enforce`/`observe`).
-- `proxy`: rewrite-applied count, rewrite-skipped-for-cache count,
-  estimated input tokens saved (bucketed), whether the prompt cache was
-  hit that day.
+- `hook_summary`: host (`claude`/`codex`), mode (`enforce`, `observe`,
+  `dry_run`), tool-call count, capped-output count, bytes saved, and estimated
+  input tokens saved.
+- `proxy_summary`: provider (`anthropic`, `openai`, `unknown`), mode
+  (`enforce`), rewrite-applied count, rewrite-skipped-for-cache count, and
+  estimated input tokens saved.
+- `active_day`: one marker per UTC day and hook host.
+- `hook_failure_summary` and `proxy_failure_summary`: one row per UTC day,
+  host/provider, and closed failure stage. Stages are `policy`, `input`,
+  `redaction`, `optimization`, `artifact`, `output`, `upstream`, and
+  `response`.
+
+All counts and byte values use fixed buckets (`zero`, `one`, `2_to_5`,
+`6_to_20`, `gt_20`; byte ranges such as `16_to_64k`). Redaction counts and
+local cache observations may remain in local diagnostics, but are not sent.
+
+It never sends partial counters for the current day; daily aggregates are sent
+only after that UTC day closes. The marker is flushed asynchronously.
 
 ## What's never collected
 
 Transcript content, tool output, file paths, session IDs, turn IDs,
 installation/device/account IDs, hostname, username, IP address, model
-name, exception text, or any other free-form or identifying field. Values
-are always bucketed, never a raw count or byte value.
+name, exception text, raw failure messages, or any other free-form or
+identifying field. Values are always bucketed, never a raw count or byte value.
 
 ## Where it goes
 
@@ -44,6 +59,9 @@ explicit choice, not evidence that the gates are complete.
 
 Retention: 13 months, aggregate rows only.
 
+The local upload queue is bounded to approximately 30 days of daily rows (up to
+4096 rows / 4 MiB); older unsent rows are evicted first during an outage.
+
 ## Controlling it
 
 There's no global `sando` command yet. Run `telemetry-cli.mjs` directly.
@@ -58,6 +76,11 @@ node packages/sando/src/telemetry-cli.mjs preview   # shows the exact next uploa
 node packages/sando/src/telemetry-cli.mjs flush
 node packages/sando/src/telemetry-cli.mjs disable --purge
 ```
+
+To disable telemetry persistently, run `disable` (optionally with `--purge` to
+remove queued local data). To disable it for a process or environment without
+changing the saved consent, set `DO_NOT_TRACK=1` (or any non-empty value other
+than `0`).
 
 **Installed via the Claude Code marketplace (`sando@yuzushi`):** the same
 script lives at `lib/telemetry-cli.mjs` inside the installed plugin

--- a/adapters/claude/sando/.claude-plugin/marketplace.json
+++ b/adapters/claude/sando/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   "plugins": [
     {
       "name": "sando",
-      "version": "0.1.5",
+      "version": "0.2.0",
       "source": "./",
       "description": "Reduce repeated tool-output context in Claude Code."
     }

--- a/adapters/claude/sando/.claude-plugin/plugin.json
+++ b/adapters/claude/sando/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sando",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "description": "Reduce repeated tool-output context in Claude Code.",
   "author": {
     "name": "Sando contributors"

--- a/adapters/claude/sando/lib/hook-entry.mjs
+++ b/adapters/claude/sando/lib/hook-entry.mjs
@@ -5,6 +5,47 @@ import path from 'node:path';
 import { createReceipt, normalizeEvent, normalizePolicy, optimizeToolOutput } from './core.mjs';
 import { defaultMetricsPath, recordMetrics } from './metrics.mjs';
 import { loadProjectRedactionProfile } from './redaction-config.mjs';
+import {
+  closeFinishedDays, defaultTelemetryConfigPath, defaultTelemetryStatePaths, incrementCounter, isDoNotTrack, readTelemetryConfig, recordActiveDay, recordFailure,
+} from './telemetry.mjs';
+import { PLUGIN_VERSION } from './version.mjs';
+
+function todayUtc() { return new Date().toISOString().slice(0, 10); }
+
+function recordHookTelemetry({ host, env, policy, optimization }) {
+  try {
+    const configPath = defaultTelemetryConfigPath(env);
+    const config = readTelemetryConfig(configPath);
+    if (!config.enabled || isDoNotTrack(env)) return;
+    const statePaths = defaultTelemetryStatePaths(env);
+    const day = todayUtc();
+    recordActiveDay({ statePaths, day, pluginVersion: PLUGIN_VERSION, host });
+    incrementCounter({
+      statePaths, day, event: 'hook_summary', host,
+      mode: policy.mode === 'apply' ? 'enforce' : policy.mode === 'dry-run' ? 'dry_run' : 'observe',
+      deltas: {
+        toolCalls: 1, redactions: optimization.stats.redactions,
+        cappedOutputs: optimization.artifact ? 1 : 0,
+        bytesSaved: Math.max(0, optimization.stats.inputBytes - optimization.stats.inlineBytes),
+        inputTokensSaved: Math.max(0, optimization.stats.estimatedInputTokens - optimization.stats.estimatedInlineTokens),
+      },
+    });
+    closeFinishedDays({ statePaths, configPath, day, pluginVersion: PLUGIN_VERSION });
+  } catch { /* telemetry is best-effort */ }
+}
+
+function recordHookFailure({ host, env, failureStage }) {
+  try {
+    const configPath = defaultTelemetryConfigPath(env);
+    const config = readTelemetryConfig(configPath);
+    if (!config.enabled || isDoNotTrack(env)) return;
+    const statePaths = defaultTelemetryStatePaths(env);
+    const day = todayUtc();
+    recordActiveDay({ statePaths, day, pluginVersion: PLUGIN_VERSION, host });
+    recordFailure({ statePaths, day, event: 'hook_failure_summary', host, failureStage });
+    closeFinishedDays({ statePaths, configPath, day, pluginVersion: PLUGIN_VERSION });
+  } catch { /* telemetry is best-effort */ }
+}
 
 function hookPolicy(env) {
   const policy = env.SANDO_POLICY
@@ -45,18 +86,23 @@ export function runHookCli({ host, env = process.env } = {}) {
   try {
     policy = hookPolicy(env);
   } catch (error) {
+    recordHookFailure({ host, env, failureStage: 'policy' });
     process.stderr.write(`sando invalid policy: ${error instanceof Error ? error.message : 'invalid input'}\n`);
     process.exitCode = 2;
     return;
   }
+  let failureStage = 'input';
   try {
     const input = JSON.parse(fs.readFileSync(0, 'utf8') || '{}');
     const eventName = input.hook_event_name ?? input.hookEventName ?? input.event_name ?? input.eventName;
     if (eventName === 'PostToolUse') {
       const event = normalizeEvent(input);
+      failureStage = 'redaction';
       const redactionProfile = policy.redact ? loadProjectRedactionProfile(event.cwd).profile : undefined;
+      failureStage = 'optimization';
       const optimization = optimizeToolOutput({ toolName: event.toolName, toolInput: event.toolInput, output: event.output, cwd: event.cwd, policy, redactionProfile });
       let shaped;
+      failureStage = 'artifact';
       if (host === 'claude' && policy.mode === 'apply') {
         shaped = shapeForClaude({
           original: event.output,
@@ -68,8 +114,10 @@ export function runHookCli({ host, env = process.env } = {}) {
           redactionProfile,
         });
       }
+      failureStage = 'output';
       const receipt = createReceipt({ host, event, optimization, replacement: shaped });
       try { recordMetrics({ storagePath: defaultMetricsPath(env), host, event, optimization, receipt }); } catch {}
+      recordHookTelemetry({ host, env, policy, optimization });
       if (host === 'codex' && policy.mode === 'apply' && env.SANDO_CODEX_FALLBACK === 'feedback') {
         process.stdout.write(`${JSON.stringify(buildCodexFallback({ optimization, cwd: event.cwd }))}\n`);
         return;
@@ -82,6 +130,7 @@ export function runHookCli({ host, env = process.env } = {}) {
       }
     }
   } catch (error) {
+    recordHookFailure({ host, env, failureStage });
     if (error?.code === 'SANDO_REDACTION_CONFIG') {
       process.stderr.write(`sando invalid redaction config: ${error.message}\n`);
       process.exitCode = 2;

--- a/adapters/claude/sando/lib/mcp-entry.mjs
+++ b/adapters/claude/sando/lib/mcp-entry.mjs
@@ -1,6 +1,7 @@
 import readline from 'node:readline';
 
 import { optimizeToolOutput } from './core.mjs';
+import { PLUGIN_VERSION } from './version.mjs';
 
 const TOOL = {
   name: 'prepare_tool_output',
@@ -19,7 +20,7 @@ function dispatch(message) {
   if (!message || message.jsonrpc !== '2.0' || typeof message.method !== 'string') return error(message?.id, -32600, 'Invalid Request');
   if (message.id === undefined) return null;
   if (message.method === 'initialize') return response(message.id, {
-    protocolVersion: message.params?.protocolVersion || '2025-06-18', capabilities: { tools: { listChanged: false } }, serverInfo: { name: 'sando', version: '0.1.0' },
+    protocolVersion: message.params?.protocolVersion || '2025-06-18', capabilities: { tools: { listChanged: false } }, serverInfo: { name: 'sando', version: PLUGIN_VERSION },
   });
   if (message.method === 'ping') return response(message.id, {});
   if (message.method === 'tools/list') return response(message.id, { tools: [TOOL] });

--- a/adapters/claude/sando/lib/mcp-server.mjs
+++ b/adapters/claude/sando/lib/mcp-server.mjs
@@ -1,6 +1,7 @@
 import readline from 'node:readline';
 
 import { optimizeToolOutput } from './core.mjs';
+import { PLUGIN_VERSION } from './version.mjs';
 
 const TOOL = {
   name: 'prepare_tool_output',
@@ -13,7 +14,7 @@ function error(id, code, message) { return { jsonrpc: '2.0', id: id ?? null, err
 function dispatch(message) {
   if (!message || message.jsonrpc !== '2.0' || typeof message.method !== 'string') return error(message?.id, -32600, 'Invalid Request');
   if (message.id === undefined) return null;
-  if (message.method === 'initialize') return response(message.id, { protocolVersion: message.params?.protocolVersion || '2025-06-18', capabilities: { tools: { listChanged: false } }, serverInfo: { name: 'sando', version: '0.1.0' } });
+  if (message.method === 'initialize') return response(message.id, { protocolVersion: message.params?.protocolVersion || '2025-06-18', capabilities: { tools: { listChanged: false } }, serverInfo: { name: 'sando', version: PLUGIN_VERSION } });
   if (message.method === 'ping') return response(message.id, {});
   if (message.method === 'tools/list') return response(message.id, { tools: [TOOL] });
   if (message.method === 'tools/call') {

--- a/adapters/claude/sando/lib/session-start.mjs
+++ b/adapters/claude/sando/lib/session-start.mjs
@@ -1,15 +1,27 @@
 import path from 'node:path';
 
-import { defaultTelemetryConfigPath, readTelemetryConfig, TELEMETRY_DETAILS_URL } from './telemetry.mjs';
+import {
+  closeFinishedDays, defaultTelemetryConfigPath, defaultTelemetryStatePaths, isDoNotTrack, readTelemetryConfig, TELEMETRY_DETAILS_URL,
+} from './telemetry.mjs';
+import { PLUGIN_VERSION } from './version.mjs';
 
 export function runSessionStart({
   env = process.env,
   stdout = process.stdout,
   rootEnv = 'PLUGIN_ROOT',
+  spawnImpl,
+  configPath = defaultTelemetryConfigPath(env),
+  statePaths = defaultTelemetryStatePaths(env),
 } = {}) {
   try {
-    const config = readTelemetryConfig(defaultTelemetryConfigPath(env));
-    if (config.prompted_consent_version > 0) {
+    const config = readTelemetryConfig(configPath);
+    if (config.enabled && !isDoNotTrack(env)) {
+      closeFinishedDays({
+        statePaths, configPath, day: new Date().toISOString().slice(0, 10),
+        pluginVersion: PLUGIN_VERSION, ...(spawnImpl ? { spawnImpl } : {}),
+      });
+    }
+    if (isDoNotTrack(env) || config.prompted_consent_version > 0) {
       stdout.write('{}\n');
       return;
     }

--- a/adapters/claude/sando/lib/telemetry-cli.mjs
+++ b/adapters/claude/sando/lib/telemetry-cli.mjs
@@ -6,7 +6,7 @@ import { pathToFileURL } from 'node:url';
 
 import {
   defaultTelemetryConfigPath, defaultTelemetryStatePaths,
-  disableTelemetry, enableTelemetry, flushQueue, previewNextUpload, statusTelemetry, TELEMETRY_DETAILS_URL,
+  disableTelemetry, enableTelemetry, flushQueue, isDoNotTrack, previewNextUpload, statusTelemetry, TELEMETRY_DETAILS_URL,
 } from './telemetry.mjs';
 
 const USAGE = 'Usage: sando telemetry <status|enable|disable [--purge]|preview|flush>\n';
@@ -26,13 +26,26 @@ export async function runTelemetryCli({
   try {
     if (command === 'status') {
       const config = statusTelemetry(configPath);
+      if (isDoNotTrack(env)) {
+        stdout.write('telemetry: disabled by DO_NOT_TRACK\n');
+        return { ...config, enabled: false };
+      }
       stdout.write(`telemetry: ${config.enabled ? 'enabled' : 'disabled'}\n`);
       return config;
     }
     if (command === 'enable') {
+      if (isDoNotTrack(env)) {
+        stderr.write('sando telemetry: DO_NOT_TRACK is set; telemetry remains disabled\n');
+        return { ...statusTelemetry(configPath), enabled: false, exitCode: 1 };
+      }
       if (!interactive) {
         stderr.write('sando telemetry: enable requires an interactive session\n');
-        return enableTelemetry({ configPath, interactive: false });
+        return { ...statusTelemetry(configPath), exitCode: 1 };
+      }
+      const current = statusTelemetry(configPath);
+      if (current.enabled) {
+        stdout.write('telemetry already enabled.\n');
+        return current;
       }
       const answer = await prompt(CONSENT_PROMPT);
       const result = enableTelemetry({
@@ -54,6 +67,10 @@ export async function runTelemetryCli({
       return preview;
     }
     if (command === 'flush') {
+      if (isDoNotTrack(env)) {
+        stdout.write('telemetry disabled by DO_NOT_TRACK; nothing to flush.\n');
+        return { sent: 0 };
+      }
       const config = statusTelemetry(configPath);
       if (!config.enabled) {
         stdout.write('telemetry is disabled; nothing to flush.\n');
@@ -72,5 +89,6 @@ export async function runTelemetryCli({
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
-  await runTelemetryCli();
+  const result = await runTelemetryCli();
+  if (result?.exitCode) process.exitCode = result.exitCode;
 }

--- a/adapters/claude/sando/lib/telemetry-flush-entry.mjs
+++ b/adapters/claude/sando/lib/telemetry-flush-entry.mjs
@@ -5,19 +5,19 @@
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 
-import { flushQueue, readTelemetryConfig } from './telemetry.mjs';
+import { flushQueue, isDoNotTrack, readTelemetryConfig } from './telemetry.mjs';
 
 function option(argv, name) {
   const index = argv.indexOf(`--${name}`);
   return index === -1 ? undefined : argv[index + 1];
 }
 
-export async function runTelemetryFlushEntry({ argv = process.argv.slice(2) } = {}) {
+export async function runTelemetryFlushEntry({ argv = process.argv.slice(2), env = process.env } = {}) {
   const queuePath = option(argv, 'queue');
   const configPath = option(argv, 'config');
   if (!queuePath || !configPath) throw new Error('telemetry-flush-entry requires --queue and --config');
   const config = readTelemetryConfig(configPath);
-  if (!config.enabled) return { sent: 0 };
+  if (!config.enabled || isDoNotTrack(env)) return { sent: 0 };
   return flushQueue({ statePaths: { queue: queuePath }, endpoint: config.endpoint });
 }
 

--- a/adapters/claude/sando/lib/telemetry.mjs
+++ b/adapters/claude/sando/lib/telemetry.mjs
@@ -13,34 +13,54 @@ const MAX_EVENT_BYTES = 2048;
 const COUNT_BUCKETS = ['zero', 'one', '2_to_5', '6_to_20', 'gt_20'];
 const BYTE_BUCKETS = ['lt_4k', '4_to_16k', '16_to_64k', 'gte_64k'];
 const HOSTS = ['claude', 'codex'];
-const MODES = ['enforce', 'observe'];
-const YES_NO_UNKNOWN = ['yes', 'no', 'unknown'];
+const PROVIDERS = ['anthropic', 'openai', 'unknown'];
+const MODES = ['enforce', 'observe', 'dry_run'];
+export const FAILURE_STAGES = [
+  'policy', 'input', 'redaction', 'optimization', 'artifact', 'output', 'upstream', 'response',
+];
 
 const SHARED_FIELDS = {
   schema_version: (value) => value === SCHEMA_VERSION,
-  event: (value) => value === 'hook_summary' || value === 'proxy_summary',
+  event: (value) => [
+    'hook_summary', 'proxy_summary', 'active_day', 'hook_failure_summary', 'proxy_failure_summary',
+  ].includes(value),
   day_utc: (value) => typeof value === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(value),
-  plugin_version: (value) => typeof value === 'string' && /^\d+\.\d+$/.test(value) && value.length <= MAX_STRING_LENGTH,
-  host: (value) => HOSTS.includes(value),
+  plugin_version: (value) => typeof value === 'string' && /^\d+\.\d+(?:\.\d+)?$/.test(value) && value.length <= MAX_STRING_LENGTH,
 };
 
 const HOOK_FIELDS = {
+  host: (value) => HOSTS.includes(value),
   mode: (value) => MODES.includes(value),
   tool_calls_bucket: (value) => COUNT_BUCKETS.includes(value),
-  redactions_bucket: (value) => COUNT_BUCKETS.includes(value),
   capped_outputs_bucket: (value) => COUNT_BUCKETS.includes(value),
   bytes_saved_bucket: (value) => BYTE_BUCKETS.includes(value),
+  input_tokens_saved_bucket: (value) => BYTE_BUCKETS.includes(value),
 };
 
 const PROXY_FIELDS = {
+  provider: (value) => PROVIDERS.includes(value),
+  mode: (value) => MODES.includes(value),
   rewrites_applied_bucket: (value) => COUNT_BUCKETS.includes(value),
   rewrites_skipped_cache_bucket: (value) => COUNT_BUCKETS.includes(value),
   input_tokens_saved_bucket: (value) => BYTE_BUCKETS.includes(value),
-  prompt_cache_hit: (value) => YES_NO_UNKNOWN.includes(value),
+};
+
+const ACTIVE_DAY_FIELDS = { host: (value) => HOSTS.includes(value) };
+const HOOK_FAILURE_FIELDS = {
+  host: (value) => HOSTS.includes(value),
+  failure_stage: (value) => FAILURE_STAGES.includes(value),
+};
+const PROXY_FAILURE_FIELDS = {
+  provider: (value) => PROVIDERS.includes(value),
+  failure_stage: (value) => FAILURE_STAGES.includes(value),
 };
 
 function fieldsForEvent(eventType) {
-  return eventType === 'hook_summary' ? HOOK_FIELDS : PROXY_FIELDS;
+  if (eventType === 'hook_summary') return HOOK_FIELDS;
+  if (eventType === 'proxy_summary') return PROXY_FIELDS;
+  if (eventType === 'active_day') return ACTIVE_DAY_FIELDS;
+  if (eventType === 'hook_failure_summary') return HOOK_FAILURE_FIELDS;
+  return PROXY_FAILURE_FIELDS;
 }
 
 export function countBucket(count) {
@@ -92,6 +112,10 @@ export const TELEMETRY_DETAILS_URL = 'https://github.com/yuzushi-dev/Sando/blob/
 // session-handoff/docs/telemetry-canary-report.md.
 export const TELEMETRY_ENDPOINT = 'https://telemetry.yuzushi.party/v1/logs';
 
+export function isDoNotTrack(env = process.env) {
+  return env.DO_NOT_TRACK !== undefined && env.DO_NOT_TRACK !== '' && env.DO_NOT_TRACK !== '0';
+}
+
 function record(value) { return value !== null && typeof value === 'object' && !Array.isArray(value); }
 
 function emptyTelemetryConfig() {
@@ -140,11 +164,10 @@ export function statusTelemetry(configPath = defaultTelemetryConfigPath()) {
   return readTelemetryConfig(configPath);
 }
 
-/** Only an explicit `yes` in an interactive session enables collection; anything else
- *  (blank, `no`, EOF, or a non-interactive caller) writes the disabled prompt marker so
- *  upgrades and reinstalls never re-prompt or silently opt a user in. */
+/** Only an explicit `yes` in an interactive session enables collection. */
 export function enableTelemetry({ configPath = defaultTelemetryConfigPath(), answer, interactive = true, now = () => new Date() } = {}) {
-  if (!interactive || typeof answer !== 'string' || answer.trim().toLowerCase() !== 'yes') {
+  if (!interactive) return { ...readTelemetryConfig(configPath), exitCode: 1 };
+  if (typeof answer !== 'string' || answer.trim().toLowerCase() !== 'yes') {
     return writeTelemetryConfig(configPath, { schema_version: TELEMETRY_CONFIG_VERSION, enabled: false, prompted_consent_version: CONSENT_VERSION });
   }
   return writeTelemetryConfig(configPath, {
@@ -157,14 +180,21 @@ export function enableTelemetry({ configPath = defaultTelemetryConfigPath(), ans
   });
 }
 
-const QUEUE_MAX_ROWS = 256;
-const QUEUE_MAX_BYTES = 256 * 1024;
+// 30 days of daily aggregates plus activity markers for both supported hosts,
+// with headroom for concurrent event dimensions and temporary outages.
+const QUEUE_MAX_ROWS = 4096;
+const QUEUE_MAX_BYTES = 4 * 1024 * 1024;
+const ACTIVE_DAY_RETENTION_DAYS = 30;
 const DEFAULT_BATCH_MAX = 32;
+const LEASE_MS = 5 * 60 * 1000;
+const RETRY_DELAYS_MS = [60_000, 300_000, 1_800_000, 7_200_000, 21_600_000];
+const CHILD_ENV_KEYS = ['HTTPS_PROXY', 'HTTP_PROXY', 'NO_PROXY', 'NODE_EXTRA_CA_CERTS', 'SSL_CERT_FILE'];
 
-function emptyCounters() { return { schema_version: TELEMETRY_CONFIG_VERSION, counters: {} }; }
+function emptyCounters() { return { schema_version: TELEMETRY_CONFIG_VERSION, counters: {}, active_days: {} }; }
 function readCounters(countersPath) {
   if (!fs.existsSync(countersPath)) return emptyCounters();
-  return JSON.parse(fs.readFileSync(countersPath, 'utf8'));
+  const state = JSON.parse(fs.readFileSync(countersPath, 'utf8'));
+  return { ...state, counters: state.counters ?? {}, active_days: state.active_days ?? {} };
 }
 
 function readQueueRows(queuePath) {
@@ -181,24 +211,29 @@ function writeQueueRows(queuePath, rows) {
   fs.chmodSync(queuePath, 0o600);
 }
 
-/** Enforces the bounded queue (256 rows / 256 KiB), dropping the oldest rows first —
+/** Enforces the bounded queue (4096 rows / 4 MiB), dropping the oldest rows first —
  *  a telemetry backlog must never grow without bound or block product behavior. */
 function appendQueueRows(queuePath, newRows) {
+  ensureDirectory(path.dirname(queuePath));
   withLock(`${queuePath}.lock`, () => {
-    let rows = [...readQueueRows(queuePath), ...newRows];
+    let rows = readQueueRows(queuePath);
+    const keys = new Set(rows.map((row) => queueKey(row)));
+    for (const row of newRows) {
+      if (!keys.has(queueKey(row))) { rows.push(row); keys.add(queueKey(row)); }
+    }
     if (rows.length > QUEUE_MAX_ROWS) rows = rows.slice(rows.length - QUEUE_MAX_ROWS);
     while (rows.length > 0 && Buffer.byteLength(rows.map((row) => JSON.stringify(row)).join('\n')) > QUEUE_MAX_BYTES) rows.shift();
     writeQueueRows(queuePath, rows);
   });
 }
 
-function majorityCacheHit(entry) {
-  const yes = entry.cacheHitYes ?? 0;
-  const no = entry.cacheHitNo ?? 0;
-  const unknown = entry.cacheHitUnknown ?? 0;
-  if (yes > no && yes >= unknown) return 'yes';
-  if (no > yes && no >= unknown) return 'no';
-  return 'unknown';
+function queueKey(row) {
+  return [row.event, row.day_utc, row.plugin_version, row.host ?? row.provider ?? '', row.mode ?? '', row.failureStage ?? row.failure_stage ?? ''].join('|');
+}
+
+function publicRow(row) {
+  const allowed = { ...SHARED_FIELDS, ...fieldsForEvent(row.event) };
+  return Object.fromEntries(Object.entries(row).filter(([key]) => Object.hasOwn(allowed, key)));
 }
 
 function bucketEntry(entry, pluginVersion) {
@@ -207,35 +242,83 @@ function bucketEntry(entry, pluginVersion) {
       schema_version: TELEMETRY_CONFIG_VERSION, event: 'hook_summary', day_utc: entry.day, plugin_version: pluginVersion,
       host: entry.host, mode: entry.mode,
       tool_calls_bucket: countBucket(entry.toolCalls ?? 0),
-      redactions_bucket: countBucket(entry.redactions ?? 0),
       capped_outputs_bucket: countBucket(entry.cappedOutputs ?? 0),
       bytes_saved_bucket: byteBucket(entry.bytesSaved ?? 0),
+      input_tokens_saved_bucket: byteBucket(entry.inputTokensSaved ?? 0),
     };
   }
-  return {
+  if (entry.event === 'proxy_summary') return {
     schema_version: TELEMETRY_CONFIG_VERSION, event: 'proxy_summary', day_utc: entry.day, plugin_version: pluginVersion,
-    host: entry.host,
+    provider: entry.provider ?? 'unknown', mode: entry.mode ?? 'enforce',
     rewrites_applied_bucket: countBucket(entry.rewritesApplied ?? 0),
     rewrites_skipped_cache_bucket: countBucket(entry.rewritesSkippedCache ?? 0),
     input_tokens_saved_bucket: byteBucket(entry.inputTokensSaved ?? 0),
-    prompt_cache_hit: majorityCacheHit(entry),
+  };
+  if (entry.event === 'hook_failure_summary') return {
+    schema_version: TELEMETRY_CONFIG_VERSION, event: 'hook_failure_summary', day_utc: entry.day, plugin_version: pluginVersion,
+    host: entry.host, failure_stage: entry.failureStage,
+  };
+  return {
+    schema_version: TELEMETRY_CONFIG_VERSION, event: 'proxy_failure_summary', day_utc: entry.day, plugin_version: pluginVersion,
+    provider: entry.provider, failure_stage: entry.failureStage,
   };
 }
 
 /** Accumulates raw per-day counts in memory/on disk; values are only bucketed (and thus
  *  only ever leave the machine) once `closeDay` closes a finished UTC day. */
-export function incrementCounter({ statePaths, day, event, host, mode, deltas = {} }) {
-  if (!['hook_summary', 'proxy_summary'].includes(event)) throw new Error('incrementCounter: invalid event');
-  const key = `${day}|${event}|${host}|${mode ?? ''}`;
+export function incrementCounter({ statePaths, day, event, host, provider, mode, failureStage, deltas = {} }) {
+  if (!['hook_summary', 'proxy_summary', 'hook_failure_summary', 'proxy_failure_summary'].includes(event)) {
+    throw new Error('incrementCounter: invalid event');
+  }
+  const isProxy = event.startsWith('proxy_');
+  const dimension = isProxy ? provider : host;
+  const key = event.includes('failure')
+    ? [day, event, dimension, failureStage ?? ''].join('|')
+    : [day, event, dimension, mode ?? ''].join('|');
   ensureDirectory(path.dirname(statePaths.counters));
   withLock(`${statePaths.counters}.lock`, () => {
     const state = readCounters(statePaths.counters);
-    const existing = state.counters[key] ?? { day, event, host, mode: mode ?? null };
+    const existing = state.counters[key] ?? {
+      day, event, ...(isProxy ? { provider: dimension } : { host: dimension }),
+      ...(event.endsWith('_summary') && !event.includes('failure') ? { mode: mode ?? null } : {}),
+      ...(event.includes('failure') ? { failureStage } : {}),
+    };
     for (const [field, value] of Object.entries(deltas)) {
       if (!Number.isInteger(value) || value < 0) throw new Error(`incrementCounter: invalid delta ${field}`);
       existing[field] = (existing[field] ?? 0) + value;
     }
     state.counters[key] = existing;
+    atomicWrite(statePaths.counters, state);
+  });
+}
+
+export function recordFailure({ statePaths, day, event, host, provider, failureStage }) {
+  incrementCounter({
+    statePaths, day, event, host, provider, failureStage, deltas: { count: 1 },
+  });
+}
+
+/** Queues a single non-aggregate activity marker for this UTC day and host. */
+export function recordActiveDay({ statePaths, day, pluginVersion, host }) {
+  const marker = {
+    schema_version: SCHEMA_VERSION, event: 'active_day', day_utc: day, plugin_version: pluginVersion, host,
+  };
+  const validatedMarker = validateEvent(marker);
+  const activeDayKey = `${day}|${host}`;
+  ensureDirectory(path.dirname(statePaths.counters));
+  withLock(`${statePaths.counters}.lock`, () => {
+    const state = readCounters(statePaths.counters);
+    const activeDays = state.active_days;
+    const cutoff = Date.parse(`${day}T00:00:00Z`) - (ACTIVE_DAY_RETENTION_DAYS - 1) * 86_400_000;
+    for (const [key, recordedDay] of Object.entries(activeDays)) {
+      if (Date.parse(`${recordedDay}T00:00:00Z`) < cutoff) delete activeDays[key];
+    }
+    if (Object.hasOwn(activeDays, activeDayKey)) {
+      atomicWrite(statePaths.counters, state);
+      return;
+    }
+    appendQueueRows(statePaths.queue, [validatedMarker]);
+    activeDays[activeDayKey] = day;
     atomicWrite(statePaths.counters, state);
   });
 }
@@ -252,11 +335,11 @@ export function closeDay({ statePaths, day, pluginVersion }) {
       if (entry.day !== day) { remaining[key] = entry; continue; }
       closedRows.push(validateEvent(bucketEntry(entry, pluginVersion)));
     }
+    if (closedRows.length) appendQueueRows(statePaths.queue, closedRows);
     state.counters = remaining;
     ensureDirectory(path.dirname(statePaths.counters));
     atomicWrite(statePaths.counters, state);
   });
-  if (closedRows.length) appendQueueRows(statePaths.queue, closedRows);
   return closedRows;
 }
 
@@ -264,14 +347,16 @@ function launchDetachedFlush({ statePaths, configPath, spawnImpl }) {
   try {
     const entryPath = fileURLToPath(new URL('./telemetry-flush-entry.mjs', import.meta.url));
     const child = spawnImpl(process.execPath, [entryPath, '--queue', statePaths.queue, '--config', configPath], {
-      detached: true, env: {}, stdio: 'ignore', windowsHide: true,
+      detached: true,
+      env: Object.fromEntries(CHILD_ENV_KEYS.filter((key) => process.env[key] !== undefined).map((key) => [key, process.env[key]])),
+      stdio: 'ignore', windowsHide: true,
     });
     child.unref();
   } catch { /* telemetry must never affect the caller */ }
 }
 
-/** Closes every raw counter day before `day` and starts one detached uploader.
- * The child receives only local state paths and an empty environment. */
+/** Closes every raw counter day before `day` and starts one detached uploader
+ * whenever any queue row remains, including a queue from a previous session. */
 export function closeFinishedDays({
   statePaths, configPath = defaultTelemetryConfigPath(), day, pluginVersion,
   spawnImpl = spawn,
@@ -287,18 +372,44 @@ export function closeFinishedDays({
   for (const closedDay of [...days].sort()) {
     closedRows.push(...closeDay({ statePaths, day: closedDay, pluginVersion }));
   }
-  if (closedRows.length) launchDetachedFlush({ statePaths, configPath, spawnImpl });
+  if (fs.existsSync(statePaths.queue) && readQueueRows(statePaths.queue).length) {
+    launchDetachedFlush({ statePaths, configPath, spawnImpl });
+  }
   return closedRows;
 }
 
-export function loadBatch({ statePaths, max = DEFAULT_BATCH_MAX } = {}) {
-  return readQueueRows(statePaths.queue).slice(0, max);
-}
-
-export function ackBatch({ statePaths, count }) {
+function claimBatch({ statePaths, max, now = Date.now, leaseMs = LEASE_MS }) {
+  let claimed = [];
   withLock(`${statePaths.queue}.lock`, () => {
     const rows = readQueueRows(statePaths.queue);
-    writeQueueRows(statePaths.queue, rows.slice(count));
+    const timestamp = now();
+    const available = rows.filter((row) => !row._permanent && (!row._nextAttemptAt || row._nextAttemptAt <= timestamp));
+    if (!available.length) return;
+    if (available.some((row) => row._leaseUntil > timestamp)) return;
+    const leaseId = `${process.pid}-${timestamp}-${Math.random().toString(36).slice(2)}`;
+    const selected = available.slice(0, max);
+    const selectedKeys = new Set(selected.map(queueKey));
+    for (const row of rows) {
+      if (selectedKeys.has(queueKey(row))) { row._leaseId = leaseId; row._leaseUntil = timestamp + leaseMs; }
+    }
+    writeQueueRows(statePaths.queue, rows);
+    claimed = selected.map((row) => ({ ...row, _leaseId: leaseId, _leaseUntil: timestamp + leaseMs }));
+  });
+  return claimed;
+}
+
+export function loadBatch({ statePaths, max = DEFAULT_BATCH_MAX, lease = true, now = Date.now } = {}) {
+  if (lease) return claimBatch({ statePaths, max, now });
+  return readQueueRows(statePaths.queue).filter((row) => !row._permanent && (!row._nextAttemptAt || row._nextAttemptAt <= now())).slice(0, max).map(publicRow);
+}
+
+export function ackBatch({ statePaths, count, leaseId } = {}) {
+  withLock(`${statePaths.queue}.lock`, () => {
+    const rows = readQueueRows(statePaths.queue);
+    if (!leaseId) { writeQueueRows(statePaths.queue, rows.slice(count)); return; }
+    const leased = rows.filter((row) => row._leaseId === leaseId).slice(0, count);
+    const keys = new Set(leased.map(queueKey));
+    writeQueueRows(statePaths.queue, rows.filter((row) => !keys.has(queueKey(row))));
   });
 }
 
@@ -309,7 +420,7 @@ export function toOtlpLogs(rows) {
       scopeLogs: [{
         logRecords: rows.map((row) => ({
           body: { stringValue: 'sando.daily_aggregate' },
-          attributes: Object.entries(row).map(([key, value]) => ({ key, value: { stringValue: String(value) } })),
+          attributes: Object.entries(publicRow(row)).map(([key, value]) => ({ key, value: { stringValue: String(value) } })),
         })),
       }],
     }],
@@ -317,30 +428,78 @@ export function toOtlpLogs(rows) {
 }
 
 export function previewNextUpload({ statePaths, endpoint = TELEMETRY_ENDPOINT, max = DEFAULT_BATCH_MAX } = {}) {
-  const rows = loadBatch({ statePaths, max });
+  const rows = loadBatch({ statePaths, max, lease: false });
   return { url: endpoint, headers: { 'content-type': 'application/json' }, body: toOtlpLogs(rows) };
 }
 
-/** Uploads at most one batch. Every failure mode (timeout, network error, non-2xx) is
- *  swallowed and reported as `sent: 0` — telemetry must never throw into, or change the
- *  outcome of, the hook or proxy call that triggered a day close. */
-export async function flushQueue({ statePaths, endpoint = TELEMETRY_ENDPOINT, max = DEFAULT_BATCH_MAX, timeoutMs = 3000 } = {}) {
-  const rows = loadBatch({ statePaths, max });
-  if (rows.length === 0) return { sent: 0 };
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), timeoutMs);
-  try {
-    const response = await fetch(endpoint, {
-      method: 'POST', headers: { 'content-type': 'application/json' },
-      body: JSON.stringify(toOtlpLogs(rows)), signal: controller.signal,
-    });
-    if (!response.ok) return { sent: 0 };
-    ackBatch({ statePaths, count: rows.length });
-    return { sent: rows.length };
-  } catch {
-    return { sent: 0 };
-  } finally {
-    clearTimeout(timer);
+/** Drains eligible batches. Every failure mode is swallowed and reported without
+ * changing the outcome of the hook or proxy call that triggered the flush. */
+function retryAfterMs(response, now) {
+  const value = response.headers?.get?.('retry-after');
+  if (!value) return 0;
+  const seconds = Number(value);
+  if (Number.isFinite(seconds)) return Math.max(0, seconds * 1000);
+  const timestamp = Date.parse(value);
+  return Number.isNaN(timestamp) ? 0 : Math.max(0, timestamp - now);
+}
+
+function updateClaimedRows({ statePaths, leaseId, update }) {
+  withLock(`${statePaths.queue}.lock`, () => {
+    const rows = readQueueRows(statePaths.queue);
+    for (const row of rows) if (row._leaseId === leaseId) update(row);
+    writeQueueRows(statePaths.queue, rows);
+  });
+}
+
+function isRetryableStatus(status) { return [429, 502, 503, 504].includes(status); }
+
+export async function flushQueue({
+  statePaths, endpoint = TELEMETRY_ENDPOINT, max = DEFAULT_BATCH_MAX, timeoutMs = 3000,
+  fetchImpl = fetch, now = Date.now, random = Math.random, sleep = async () => {},
+} = {}) {
+  const result = { sent: 0, rejectedLogRecords: 0 };
+  while (true) {
+    const rows = claimBatch({ statePaths, max, now });
+    if (rows.length === 0) return result;
+    const leaseId = rows[0]._leaseId;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      const response = await fetchImpl(endpoint, {
+        method: 'POST', headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(toOtlpLogs(rows)), signal: controller.signal,
+      });
+      if (response.ok) {
+        let body = {};
+        try { body = await response.json(); } catch { /* empty 2xx body */ }
+        result.rejectedLogRecords += Number(body?.partialSuccess?.rejectedLogRecords || 0);
+        ackBatch({ statePaths, count: rows.length, leaseId });
+        result.sent += rows.length;
+      } else if (isRetryableStatus(response.status)) {
+        updateClaimedRows({ statePaths, leaseId, update: (row) => {
+          const attempt = (row._attemptCount ?? 0) + 1;
+          const base = RETRY_DELAYS_MS[Math.min(attempt - 1, RETRY_DELAYS_MS.length - 1)];
+          row._attemptCount = attempt;
+          row._nextAttemptAt = now() + Math.max(base * random(), retryAfterMs(response, now()));
+          delete row._leaseId; delete row._leaseUntil;
+        }});
+        return result;
+      } else {
+        ackBatch({ statePaths, count: rows.length, leaseId });
+      }
+    } catch {
+      updateClaimedRows({ statePaths, leaseId, update: (row) => {
+        const attempt = (row._attemptCount ?? 0) + 1;
+        const base = RETRY_DELAYS_MS[Math.min(attempt - 1, RETRY_DELAYS_MS.length - 1)];
+        row._attemptCount = attempt;
+        row._nextAttemptAt = now() + base * random();
+        delete row._leaseId; delete row._leaseUntil;
+      }});
+      return result;
+    } finally {
+      clearTimeout(timer);
+    }
+    await sleep(0);
   }
 }
 

--- a/adapters/claude/sando/lib/version.mjs
+++ b/adapters/claude/sando/lib/version.mjs
@@ -1,0 +1,29 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const VERSION_PATTERN = /^\d+\.\d+(?:\.\d+)?$/;
+const STANDALONE_VERSION = '0.2.0';
+const METADATA_FILES = ['package.json', '.claude-plugin/plugin.json', '.codex-plugin/plugin.json'];
+
+function findMetadataFile() {
+  let directory = path.resolve(import.meta.dirname, '..');
+  while (true) {
+    for (const relativePath of METADATA_FILES) {
+      const file = path.join(directory, relativePath);
+      if (fs.existsSync(file)) return file;
+    }
+    const parent = path.dirname(directory);
+    if (parent === directory) break;
+    directory = parent;
+  }
+  return null;
+}
+
+const metadataPath = findMetadataFile();
+const metadata = metadataPath ? JSON.parse(fs.readFileSync(metadataPath, 'utf8')) : { version: STANDALONE_VERSION };
+if (typeof metadata.version !== 'string' || !VERSION_PATTERN.test(metadata.version)) {
+  throw new Error(`Invalid Sando version in ${metadataPath}`);
+}
+
+// Evaluated once per process: no repeated filesystem reads in telemetry paths.
+export const PLUGIN_VERSION = metadata.version;

--- a/adapters/claude/sando/tests/session-start-hook.test.mjs
+++ b/adapters/claude/sando/tests/session-start-hook.test.mjs
@@ -57,3 +57,10 @@ test('a corrupt config file never crashes the hook or blocks the session', (t) =
   const output = run({ XDG_CONFIG_HOME: path.join(directory, '.config') });
   assert.deepEqual(output, {});
 });
+
+test('DO_NOT_TRACK suppresses the first-use telemetry notice', (t) => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'sando-session-start-'));
+  t.after(() => fs.rmSync(directory, { recursive: true, force: true }));
+  const output = run({ XDG_CONFIG_HOME: path.join(directory, '.config'), DO_NOT_TRACK: '1' });
+  assert.deepEqual(output, {});
+});

--- a/adapters/codex/sando/lib/hook-entry.mjs
+++ b/adapters/codex/sando/lib/hook-entry.mjs
@@ -5,6 +5,47 @@ import path from 'node:path';
 import { createReceipt, normalizeEvent, normalizePolicy, optimizeToolOutput } from './core.mjs';
 import { defaultMetricsPath, recordMetrics } from './metrics.mjs';
 import { loadProjectRedactionProfile } from './redaction-config.mjs';
+import {
+  closeFinishedDays, defaultTelemetryConfigPath, defaultTelemetryStatePaths, incrementCounter, isDoNotTrack, readTelemetryConfig, recordActiveDay, recordFailure,
+} from './telemetry.mjs';
+import { PLUGIN_VERSION } from './version.mjs';
+
+function todayUtc() { return new Date().toISOString().slice(0, 10); }
+
+function recordHookTelemetry({ host, env, policy, optimization }) {
+  try {
+    const configPath = defaultTelemetryConfigPath(env);
+    const config = readTelemetryConfig(configPath);
+    if (!config.enabled || isDoNotTrack(env)) return;
+    const statePaths = defaultTelemetryStatePaths(env);
+    const day = todayUtc();
+    recordActiveDay({ statePaths, day, pluginVersion: PLUGIN_VERSION, host });
+    incrementCounter({
+      statePaths, day, event: 'hook_summary', host,
+      mode: policy.mode === 'apply' ? 'enforce' : policy.mode === 'dry-run' ? 'dry_run' : 'observe',
+      deltas: {
+        toolCalls: 1, redactions: optimization.stats.redactions,
+        cappedOutputs: optimization.artifact ? 1 : 0,
+        bytesSaved: Math.max(0, optimization.stats.inputBytes - optimization.stats.inlineBytes),
+        inputTokensSaved: Math.max(0, optimization.stats.estimatedInputTokens - optimization.stats.estimatedInlineTokens),
+      },
+    });
+    closeFinishedDays({ statePaths, configPath, day, pluginVersion: PLUGIN_VERSION });
+  } catch { /* telemetry is best-effort */ }
+}
+
+function recordHookFailure({ host, env, failureStage }) {
+  try {
+    const configPath = defaultTelemetryConfigPath(env);
+    const config = readTelemetryConfig(configPath);
+    if (!config.enabled || isDoNotTrack(env)) return;
+    const statePaths = defaultTelemetryStatePaths(env);
+    const day = todayUtc();
+    recordActiveDay({ statePaths, day, pluginVersion: PLUGIN_VERSION, host });
+    recordFailure({ statePaths, day, event: 'hook_failure_summary', host, failureStage });
+    closeFinishedDays({ statePaths, configPath, day, pluginVersion: PLUGIN_VERSION });
+  } catch { /* telemetry is best-effort */ }
+}
 
 function hookPolicy(env) {
   const policy = env.SANDO_POLICY
@@ -45,20 +86,27 @@ export function runHookCli({ host, env = process.env } = {}) {
   try {
     policy = hookPolicy(env);
   } catch (error) {
+    recordHookFailure({ host, env, failureStage: 'policy' });
     process.stderr.write(`sando invalid policy: ${error instanceof Error ? error.message : 'invalid input'}\n`);
     process.exitCode = 2;
     return;
   }
+  let failureStage = 'input';
   try {
     const input = JSON.parse(fs.readFileSync(0, 'utf8') || '{}');
     const eventName = input.hook_event_name ?? input.hookEventName ?? input.event_name ?? input.eventName;
     if (eventName === 'PostToolUse') {
       const event = normalizeEvent(input);
+      failureStage = 'redaction';
       const redactionProfile = policy.redact ? loadProjectRedactionProfile(event.cwd).profile : undefined;
+      failureStage = 'optimization';
       const optimization = optimizeToolOutput({ toolName: event.toolName, toolInput: event.toolInput, output: event.output, cwd: event.cwd, policy, redactionProfile });
+      failureStage = 'output';
       const receipt = createReceipt({ host, event, optimization });
       try { recordMetrics({ storagePath: defaultMetricsPath(env), host, event, optimization, receipt }); } catch {}
+      recordHookTelemetry({ host, env, policy, optimization });
       if (host === 'codex' && policy.mode === 'apply' && env.SANDO_CODEX_FALLBACK === 'feedback') {
+        failureStage = 'artifact';
         process.stdout.write(`${JSON.stringify(buildCodexFallback({ optimization, cwd: event.cwd }))}\n`);
         return;
       }
@@ -81,6 +129,7 @@ export function runHookCli({ host, env = process.env } = {}) {
       }
     }
   } catch (error) {
+    recordHookFailure({ host, env, failureStage });
     if (error?.code === 'SANDO_REDACTION_CONFIG') {
       process.stderr.write(`sando invalid redaction config: ${error.message}\n`);
       process.exitCode = 2;

--- a/adapters/codex/sando/lib/mcp-entry.mjs
+++ b/adapters/codex/sando/lib/mcp-entry.mjs
@@ -1,6 +1,7 @@
 import readline from 'node:readline';
 
 import { callMcpToolAsync, MCP_TOOLS } from './mcp-tools.mjs';
+import { PLUGIN_VERSION } from './version.mjs';
 
 function response(id, result) { return { jsonrpc: '2.0', id, result }; }
 function error(id, code, message) { return { jsonrpc: '2.0', id: id ?? null, error: { code, message } }; }
@@ -13,7 +14,7 @@ async function dispatch(message, active) {
   }
   if (message.id === undefined) return null;
   if (message.method === 'initialize') return response(message.id, {
-    protocolVersion: message.params?.protocolVersion || '2025-06-18', capabilities: { tools: { listChanged: false }, experimental: { 'codex/sandbox-state-meta': {} } }, serverInfo: { name: 'sando', version: '0.1.0' },
+    protocolVersion: message.params?.protocolVersion || '2025-06-18', capabilities: { tools: { listChanged: false }, experimental: { 'codex/sandbox-state-meta': {} } }, serverInfo: { name: 'sando', version: PLUGIN_VERSION },
   });
   if (message.method === 'ping') return response(message.id, {});
   if (message.method === 'tools/list') return response(message.id, { tools: MCP_TOOLS });

--- a/adapters/codex/sando/lib/mcp-server.mjs
+++ b/adapters/codex/sando/lib/mcp-server.mjs
@@ -1,6 +1,7 @@
 import readline from 'node:readline';
 
 import { optimizeToolOutput } from './core.mjs';
+import { PLUGIN_VERSION } from './version.mjs';
 
 const TOOL = {
   name: 'prepare_tool_output',
@@ -13,7 +14,7 @@ function error(id, code, message) { return { jsonrpc: '2.0', id: id ?? null, err
 function dispatch(message) {
   if (!message || message.jsonrpc !== '2.0' || typeof message.method !== 'string') return error(message?.id, -32600, 'Invalid Request');
   if (message.id === undefined) return null;
-  if (message.method === 'initialize') return response(message.id, { protocolVersion: message.params?.protocolVersion || '2025-06-18', capabilities: { tools: { listChanged: false } }, serverInfo: { name: 'sando', version: '0.1.0' } });
+  if (message.method === 'initialize') return response(message.id, { protocolVersion: message.params?.protocolVersion || '2025-06-18', capabilities: { tools: { listChanged: false } }, serverInfo: { name: 'sando', version: PLUGIN_VERSION } });
   if (message.method === 'ping') return response(message.id, {});
   if (message.method === 'tools/list') return response(message.id, { tools: [TOOL] });
   if (message.method === 'tools/call') {

--- a/adapters/codex/sando/lib/session-start.mjs
+++ b/adapters/codex/sando/lib/session-start.mjs
@@ -1,15 +1,27 @@
 import path from 'node:path';
 
-import { defaultTelemetryConfigPath, readTelemetryConfig, TELEMETRY_DETAILS_URL } from './telemetry.mjs';
+import {
+  closeFinishedDays, defaultTelemetryConfigPath, defaultTelemetryStatePaths, isDoNotTrack, readTelemetryConfig, TELEMETRY_DETAILS_URL,
+} from './telemetry.mjs';
+import { PLUGIN_VERSION } from './version.mjs';
 
 export function runSessionStart({
   env = process.env,
   stdout = process.stdout,
   rootEnv = 'PLUGIN_ROOT',
+  spawnImpl,
+  configPath = defaultTelemetryConfigPath(env),
+  statePaths = defaultTelemetryStatePaths(env),
 } = {}) {
   try {
-    const config = readTelemetryConfig(defaultTelemetryConfigPath(env));
-    if (config.prompted_consent_version > 0) {
+    const config = readTelemetryConfig(configPath);
+    if (config.enabled && !isDoNotTrack(env)) {
+      closeFinishedDays({
+        statePaths, configPath, day: new Date().toISOString().slice(0, 10),
+        pluginVersion: PLUGIN_VERSION, ...(spawnImpl ? { spawnImpl } : {}),
+      });
+    }
+    if (isDoNotTrack(env) || config.prompted_consent_version > 0) {
       stdout.write('{}\n');
       return;
     }

--- a/adapters/codex/sando/lib/telemetry-cli.mjs
+++ b/adapters/codex/sando/lib/telemetry-cli.mjs
@@ -6,7 +6,7 @@ import { pathToFileURL } from 'node:url';
 
 import {
   defaultTelemetryConfigPath, defaultTelemetryStatePaths,
-  disableTelemetry, enableTelemetry, flushQueue, previewNextUpload, statusTelemetry, TELEMETRY_DETAILS_URL,
+  disableTelemetry, enableTelemetry, flushQueue, isDoNotTrack, previewNextUpload, statusTelemetry, TELEMETRY_DETAILS_URL,
 } from './telemetry.mjs';
 
 const USAGE = 'Usage: sando telemetry <status|enable|disable [--purge]|preview|flush>\n';
@@ -26,13 +26,26 @@ export async function runTelemetryCli({
   try {
     if (command === 'status') {
       const config = statusTelemetry(configPath);
+      if (isDoNotTrack(env)) {
+        stdout.write('telemetry: disabled by DO_NOT_TRACK\n');
+        return { ...config, enabled: false };
+      }
       stdout.write(`telemetry: ${config.enabled ? 'enabled' : 'disabled'}\n`);
       return config;
     }
     if (command === 'enable') {
+      if (isDoNotTrack(env)) {
+        stderr.write('sando telemetry: DO_NOT_TRACK is set; telemetry remains disabled\n');
+        return { ...statusTelemetry(configPath), enabled: false, exitCode: 1 };
+      }
       if (!interactive) {
         stderr.write('sando telemetry: enable requires an interactive session\n');
-        return enableTelemetry({ configPath, interactive: false });
+        return { ...statusTelemetry(configPath), exitCode: 1 };
+      }
+      const current = statusTelemetry(configPath);
+      if (current.enabled) {
+        stdout.write('telemetry already enabled.\n');
+        return current;
       }
       const answer = await prompt(CONSENT_PROMPT);
       const result = enableTelemetry({
@@ -54,6 +67,10 @@ export async function runTelemetryCli({
       return preview;
     }
     if (command === 'flush') {
+      if (isDoNotTrack(env)) {
+        stdout.write('telemetry disabled by DO_NOT_TRACK; nothing to flush.\n');
+        return { sent: 0 };
+      }
       const config = statusTelemetry(configPath);
       if (!config.enabled) {
         stdout.write('telemetry is disabled; nothing to flush.\n');
@@ -72,5 +89,6 @@ export async function runTelemetryCli({
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
-  await runTelemetryCli();
+  const result = await runTelemetryCli();
+  if (result?.exitCode) process.exitCode = result.exitCode;
 }

--- a/adapters/codex/sando/lib/telemetry-flush-entry.mjs
+++ b/adapters/codex/sando/lib/telemetry-flush-entry.mjs
@@ -5,19 +5,19 @@
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 
-import { flushQueue, readTelemetryConfig } from './telemetry.mjs';
+import { flushQueue, isDoNotTrack, readTelemetryConfig } from './telemetry.mjs';
 
 function option(argv, name) {
   const index = argv.indexOf(`--${name}`);
   return index === -1 ? undefined : argv[index + 1];
 }
 
-export async function runTelemetryFlushEntry({ argv = process.argv.slice(2) } = {}) {
+export async function runTelemetryFlushEntry({ argv = process.argv.slice(2), env = process.env } = {}) {
   const queuePath = option(argv, 'queue');
   const configPath = option(argv, 'config');
   if (!queuePath || !configPath) throw new Error('telemetry-flush-entry requires --queue and --config');
   const config = readTelemetryConfig(configPath);
-  if (!config.enabled) return { sent: 0 };
+  if (!config.enabled || isDoNotTrack(env)) return { sent: 0 };
   return flushQueue({ statePaths: { queue: queuePath }, endpoint: config.endpoint });
 }
 

--- a/adapters/codex/sando/lib/telemetry.mjs
+++ b/adapters/codex/sando/lib/telemetry.mjs
@@ -13,34 +13,54 @@ const MAX_EVENT_BYTES = 2048;
 const COUNT_BUCKETS = ['zero', 'one', '2_to_5', '6_to_20', 'gt_20'];
 const BYTE_BUCKETS = ['lt_4k', '4_to_16k', '16_to_64k', 'gte_64k'];
 const HOSTS = ['claude', 'codex'];
-const MODES = ['enforce', 'observe'];
-const YES_NO_UNKNOWN = ['yes', 'no', 'unknown'];
+const PROVIDERS = ['anthropic', 'openai', 'unknown'];
+const MODES = ['enforce', 'observe', 'dry_run'];
+export const FAILURE_STAGES = [
+  'policy', 'input', 'redaction', 'optimization', 'artifact', 'output', 'upstream', 'response',
+];
 
 const SHARED_FIELDS = {
   schema_version: (value) => value === SCHEMA_VERSION,
-  event: (value) => value === 'hook_summary' || value === 'proxy_summary',
+  event: (value) => [
+    'hook_summary', 'proxy_summary', 'active_day', 'hook_failure_summary', 'proxy_failure_summary',
+  ].includes(value),
   day_utc: (value) => typeof value === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(value),
-  plugin_version: (value) => typeof value === 'string' && /^\d+\.\d+$/.test(value) && value.length <= MAX_STRING_LENGTH,
-  host: (value) => HOSTS.includes(value),
+  plugin_version: (value) => typeof value === 'string' && /^\d+\.\d+(?:\.\d+)?$/.test(value) && value.length <= MAX_STRING_LENGTH,
 };
 
 const HOOK_FIELDS = {
+  host: (value) => HOSTS.includes(value),
   mode: (value) => MODES.includes(value),
   tool_calls_bucket: (value) => COUNT_BUCKETS.includes(value),
-  redactions_bucket: (value) => COUNT_BUCKETS.includes(value),
   capped_outputs_bucket: (value) => COUNT_BUCKETS.includes(value),
   bytes_saved_bucket: (value) => BYTE_BUCKETS.includes(value),
+  input_tokens_saved_bucket: (value) => BYTE_BUCKETS.includes(value),
 };
 
 const PROXY_FIELDS = {
+  provider: (value) => PROVIDERS.includes(value),
+  mode: (value) => MODES.includes(value),
   rewrites_applied_bucket: (value) => COUNT_BUCKETS.includes(value),
   rewrites_skipped_cache_bucket: (value) => COUNT_BUCKETS.includes(value),
   input_tokens_saved_bucket: (value) => BYTE_BUCKETS.includes(value),
-  prompt_cache_hit: (value) => YES_NO_UNKNOWN.includes(value),
+};
+
+const ACTIVE_DAY_FIELDS = { host: (value) => HOSTS.includes(value) };
+const HOOK_FAILURE_FIELDS = {
+  host: (value) => HOSTS.includes(value),
+  failure_stage: (value) => FAILURE_STAGES.includes(value),
+};
+const PROXY_FAILURE_FIELDS = {
+  provider: (value) => PROVIDERS.includes(value),
+  failure_stage: (value) => FAILURE_STAGES.includes(value),
 };
 
 function fieldsForEvent(eventType) {
-  return eventType === 'hook_summary' ? HOOK_FIELDS : PROXY_FIELDS;
+  if (eventType === 'hook_summary') return HOOK_FIELDS;
+  if (eventType === 'proxy_summary') return PROXY_FIELDS;
+  if (eventType === 'active_day') return ACTIVE_DAY_FIELDS;
+  if (eventType === 'hook_failure_summary') return HOOK_FAILURE_FIELDS;
+  return PROXY_FAILURE_FIELDS;
 }
 
 export function countBucket(count) {
@@ -92,6 +112,10 @@ export const TELEMETRY_DETAILS_URL = 'https://github.com/yuzushi-dev/Sando/blob/
 // session-handoff/docs/telemetry-canary-report.md.
 export const TELEMETRY_ENDPOINT = 'https://telemetry.yuzushi.party/v1/logs';
 
+export function isDoNotTrack(env = process.env) {
+  return env.DO_NOT_TRACK !== undefined && env.DO_NOT_TRACK !== '' && env.DO_NOT_TRACK !== '0';
+}
+
 function record(value) { return value !== null && typeof value === 'object' && !Array.isArray(value); }
 
 function emptyTelemetryConfig() {
@@ -140,11 +164,10 @@ export function statusTelemetry(configPath = defaultTelemetryConfigPath()) {
   return readTelemetryConfig(configPath);
 }
 
-/** Only an explicit `yes` in an interactive session enables collection; anything else
- *  (blank, `no`, EOF, or a non-interactive caller) writes the disabled prompt marker so
- *  upgrades and reinstalls never re-prompt or silently opt a user in. */
+/** Only an explicit `yes` in an interactive session enables collection. */
 export function enableTelemetry({ configPath = defaultTelemetryConfigPath(), answer, interactive = true, now = () => new Date() } = {}) {
-  if (!interactive || typeof answer !== 'string' || answer.trim().toLowerCase() !== 'yes') {
+  if (!interactive) return { ...readTelemetryConfig(configPath), exitCode: 1 };
+  if (typeof answer !== 'string' || answer.trim().toLowerCase() !== 'yes') {
     return writeTelemetryConfig(configPath, { schema_version: TELEMETRY_CONFIG_VERSION, enabled: false, prompted_consent_version: CONSENT_VERSION });
   }
   return writeTelemetryConfig(configPath, {
@@ -157,14 +180,21 @@ export function enableTelemetry({ configPath = defaultTelemetryConfigPath(), ans
   });
 }
 
-const QUEUE_MAX_ROWS = 256;
-const QUEUE_MAX_BYTES = 256 * 1024;
+// 30 days of daily aggregates plus activity markers for both supported hosts,
+// with headroom for concurrent event dimensions and temporary outages.
+const QUEUE_MAX_ROWS = 4096;
+const QUEUE_MAX_BYTES = 4 * 1024 * 1024;
+const ACTIVE_DAY_RETENTION_DAYS = 30;
 const DEFAULT_BATCH_MAX = 32;
+const LEASE_MS = 5 * 60 * 1000;
+const RETRY_DELAYS_MS = [60_000, 300_000, 1_800_000, 7_200_000, 21_600_000];
+const CHILD_ENV_KEYS = ['HTTPS_PROXY', 'HTTP_PROXY', 'NO_PROXY', 'NODE_EXTRA_CA_CERTS', 'SSL_CERT_FILE'];
 
-function emptyCounters() { return { schema_version: TELEMETRY_CONFIG_VERSION, counters: {} }; }
+function emptyCounters() { return { schema_version: TELEMETRY_CONFIG_VERSION, counters: {}, active_days: {} }; }
 function readCounters(countersPath) {
   if (!fs.existsSync(countersPath)) return emptyCounters();
-  return JSON.parse(fs.readFileSync(countersPath, 'utf8'));
+  const state = JSON.parse(fs.readFileSync(countersPath, 'utf8'));
+  return { ...state, counters: state.counters ?? {}, active_days: state.active_days ?? {} };
 }
 
 function readQueueRows(queuePath) {
@@ -181,24 +211,29 @@ function writeQueueRows(queuePath, rows) {
   fs.chmodSync(queuePath, 0o600);
 }
 
-/** Enforces the bounded queue (256 rows / 256 KiB), dropping the oldest rows first —
+/** Enforces the bounded queue (4096 rows / 4 MiB), dropping the oldest rows first —
  *  a telemetry backlog must never grow without bound or block product behavior. */
 function appendQueueRows(queuePath, newRows) {
+  ensureDirectory(path.dirname(queuePath));
   withLock(`${queuePath}.lock`, () => {
-    let rows = [...readQueueRows(queuePath), ...newRows];
+    let rows = readQueueRows(queuePath);
+    const keys = new Set(rows.map((row) => queueKey(row)));
+    for (const row of newRows) {
+      if (!keys.has(queueKey(row))) { rows.push(row); keys.add(queueKey(row)); }
+    }
     if (rows.length > QUEUE_MAX_ROWS) rows = rows.slice(rows.length - QUEUE_MAX_ROWS);
     while (rows.length > 0 && Buffer.byteLength(rows.map((row) => JSON.stringify(row)).join('\n')) > QUEUE_MAX_BYTES) rows.shift();
     writeQueueRows(queuePath, rows);
   });
 }
 
-function majorityCacheHit(entry) {
-  const yes = entry.cacheHitYes ?? 0;
-  const no = entry.cacheHitNo ?? 0;
-  const unknown = entry.cacheHitUnknown ?? 0;
-  if (yes > no && yes >= unknown) return 'yes';
-  if (no > yes && no >= unknown) return 'no';
-  return 'unknown';
+function queueKey(row) {
+  return [row.event, row.day_utc, row.plugin_version, row.host ?? row.provider ?? '', row.mode ?? '', row.failureStage ?? row.failure_stage ?? ''].join('|');
+}
+
+function publicRow(row) {
+  const allowed = { ...SHARED_FIELDS, ...fieldsForEvent(row.event) };
+  return Object.fromEntries(Object.entries(row).filter(([key]) => Object.hasOwn(allowed, key)));
 }
 
 function bucketEntry(entry, pluginVersion) {
@@ -207,35 +242,83 @@ function bucketEntry(entry, pluginVersion) {
       schema_version: TELEMETRY_CONFIG_VERSION, event: 'hook_summary', day_utc: entry.day, plugin_version: pluginVersion,
       host: entry.host, mode: entry.mode,
       tool_calls_bucket: countBucket(entry.toolCalls ?? 0),
-      redactions_bucket: countBucket(entry.redactions ?? 0),
       capped_outputs_bucket: countBucket(entry.cappedOutputs ?? 0),
       bytes_saved_bucket: byteBucket(entry.bytesSaved ?? 0),
+      input_tokens_saved_bucket: byteBucket(entry.inputTokensSaved ?? 0),
     };
   }
-  return {
+  if (entry.event === 'proxy_summary') return {
     schema_version: TELEMETRY_CONFIG_VERSION, event: 'proxy_summary', day_utc: entry.day, plugin_version: pluginVersion,
-    host: entry.host,
+    provider: entry.provider ?? 'unknown', mode: entry.mode ?? 'enforce',
     rewrites_applied_bucket: countBucket(entry.rewritesApplied ?? 0),
     rewrites_skipped_cache_bucket: countBucket(entry.rewritesSkippedCache ?? 0),
     input_tokens_saved_bucket: byteBucket(entry.inputTokensSaved ?? 0),
-    prompt_cache_hit: majorityCacheHit(entry),
+  };
+  if (entry.event === 'hook_failure_summary') return {
+    schema_version: TELEMETRY_CONFIG_VERSION, event: 'hook_failure_summary', day_utc: entry.day, plugin_version: pluginVersion,
+    host: entry.host, failure_stage: entry.failureStage,
+  };
+  return {
+    schema_version: TELEMETRY_CONFIG_VERSION, event: 'proxy_failure_summary', day_utc: entry.day, plugin_version: pluginVersion,
+    provider: entry.provider, failure_stage: entry.failureStage,
   };
 }
 
 /** Accumulates raw per-day counts in memory/on disk; values are only bucketed (and thus
  *  only ever leave the machine) once `closeDay` closes a finished UTC day. */
-export function incrementCounter({ statePaths, day, event, host, mode, deltas = {} }) {
-  if (!['hook_summary', 'proxy_summary'].includes(event)) throw new Error('incrementCounter: invalid event');
-  const key = `${day}|${event}|${host}|${mode ?? ''}`;
+export function incrementCounter({ statePaths, day, event, host, provider, mode, failureStage, deltas = {} }) {
+  if (!['hook_summary', 'proxy_summary', 'hook_failure_summary', 'proxy_failure_summary'].includes(event)) {
+    throw new Error('incrementCounter: invalid event');
+  }
+  const isProxy = event.startsWith('proxy_');
+  const dimension = isProxy ? provider : host;
+  const key = event.includes('failure')
+    ? [day, event, dimension, failureStage ?? ''].join('|')
+    : [day, event, dimension, mode ?? ''].join('|');
   ensureDirectory(path.dirname(statePaths.counters));
   withLock(`${statePaths.counters}.lock`, () => {
     const state = readCounters(statePaths.counters);
-    const existing = state.counters[key] ?? { day, event, host, mode: mode ?? null };
+    const existing = state.counters[key] ?? {
+      day, event, ...(isProxy ? { provider: dimension } : { host: dimension }),
+      ...(event.endsWith('_summary') && !event.includes('failure') ? { mode: mode ?? null } : {}),
+      ...(event.includes('failure') ? { failureStage } : {}),
+    };
     for (const [field, value] of Object.entries(deltas)) {
       if (!Number.isInteger(value) || value < 0) throw new Error(`incrementCounter: invalid delta ${field}`);
       existing[field] = (existing[field] ?? 0) + value;
     }
     state.counters[key] = existing;
+    atomicWrite(statePaths.counters, state);
+  });
+}
+
+export function recordFailure({ statePaths, day, event, host, provider, failureStage }) {
+  incrementCounter({
+    statePaths, day, event, host, provider, failureStage, deltas: { count: 1 },
+  });
+}
+
+/** Queues a single non-aggregate activity marker for this UTC day and host. */
+export function recordActiveDay({ statePaths, day, pluginVersion, host }) {
+  const marker = {
+    schema_version: SCHEMA_VERSION, event: 'active_day', day_utc: day, plugin_version: pluginVersion, host,
+  };
+  const validatedMarker = validateEvent(marker);
+  const activeDayKey = `${day}|${host}`;
+  ensureDirectory(path.dirname(statePaths.counters));
+  withLock(`${statePaths.counters}.lock`, () => {
+    const state = readCounters(statePaths.counters);
+    const activeDays = state.active_days;
+    const cutoff = Date.parse(`${day}T00:00:00Z`) - (ACTIVE_DAY_RETENTION_DAYS - 1) * 86_400_000;
+    for (const [key, recordedDay] of Object.entries(activeDays)) {
+      if (Date.parse(`${recordedDay}T00:00:00Z`) < cutoff) delete activeDays[key];
+    }
+    if (Object.hasOwn(activeDays, activeDayKey)) {
+      atomicWrite(statePaths.counters, state);
+      return;
+    }
+    appendQueueRows(statePaths.queue, [validatedMarker]);
+    activeDays[activeDayKey] = day;
     atomicWrite(statePaths.counters, state);
   });
 }
@@ -252,11 +335,11 @@ export function closeDay({ statePaths, day, pluginVersion }) {
       if (entry.day !== day) { remaining[key] = entry; continue; }
       closedRows.push(validateEvent(bucketEntry(entry, pluginVersion)));
     }
+    if (closedRows.length) appendQueueRows(statePaths.queue, closedRows);
     state.counters = remaining;
     ensureDirectory(path.dirname(statePaths.counters));
     atomicWrite(statePaths.counters, state);
   });
-  if (closedRows.length) appendQueueRows(statePaths.queue, closedRows);
   return closedRows;
 }
 
@@ -264,14 +347,16 @@ function launchDetachedFlush({ statePaths, configPath, spawnImpl }) {
   try {
     const entryPath = fileURLToPath(new URL('./telemetry-flush-entry.mjs', import.meta.url));
     const child = spawnImpl(process.execPath, [entryPath, '--queue', statePaths.queue, '--config', configPath], {
-      detached: true, env: {}, stdio: 'ignore', windowsHide: true,
+      detached: true,
+      env: Object.fromEntries(CHILD_ENV_KEYS.filter((key) => process.env[key] !== undefined).map((key) => [key, process.env[key]])),
+      stdio: 'ignore', windowsHide: true,
     });
     child.unref();
   } catch { /* telemetry must never affect the caller */ }
 }
 
-/** Closes every raw counter day before `day` and starts one detached uploader.
- * The child receives only local state paths and an empty environment. */
+/** Closes every raw counter day before `day` and starts one detached uploader
+ * whenever any queue row remains, including a queue from a previous session. */
 export function closeFinishedDays({
   statePaths, configPath = defaultTelemetryConfigPath(), day, pluginVersion,
   spawnImpl = spawn,
@@ -287,18 +372,44 @@ export function closeFinishedDays({
   for (const closedDay of [...days].sort()) {
     closedRows.push(...closeDay({ statePaths, day: closedDay, pluginVersion }));
   }
-  if (closedRows.length) launchDetachedFlush({ statePaths, configPath, spawnImpl });
+  if (fs.existsSync(statePaths.queue) && readQueueRows(statePaths.queue).length) {
+    launchDetachedFlush({ statePaths, configPath, spawnImpl });
+  }
   return closedRows;
 }
 
-export function loadBatch({ statePaths, max = DEFAULT_BATCH_MAX } = {}) {
-  return readQueueRows(statePaths.queue).slice(0, max);
-}
-
-export function ackBatch({ statePaths, count }) {
+function claimBatch({ statePaths, max, now = Date.now, leaseMs = LEASE_MS }) {
+  let claimed = [];
   withLock(`${statePaths.queue}.lock`, () => {
     const rows = readQueueRows(statePaths.queue);
-    writeQueueRows(statePaths.queue, rows.slice(count));
+    const timestamp = now();
+    const available = rows.filter((row) => !row._permanent && (!row._nextAttemptAt || row._nextAttemptAt <= timestamp));
+    if (!available.length) return;
+    if (available.some((row) => row._leaseUntil > timestamp)) return;
+    const leaseId = `${process.pid}-${timestamp}-${Math.random().toString(36).slice(2)}`;
+    const selected = available.slice(0, max);
+    const selectedKeys = new Set(selected.map(queueKey));
+    for (const row of rows) {
+      if (selectedKeys.has(queueKey(row))) { row._leaseId = leaseId; row._leaseUntil = timestamp + leaseMs; }
+    }
+    writeQueueRows(statePaths.queue, rows);
+    claimed = selected.map((row) => ({ ...row, _leaseId: leaseId, _leaseUntil: timestamp + leaseMs }));
+  });
+  return claimed;
+}
+
+export function loadBatch({ statePaths, max = DEFAULT_BATCH_MAX, lease = true, now = Date.now } = {}) {
+  if (lease) return claimBatch({ statePaths, max, now });
+  return readQueueRows(statePaths.queue).filter((row) => !row._permanent && (!row._nextAttemptAt || row._nextAttemptAt <= now())).slice(0, max).map(publicRow);
+}
+
+export function ackBatch({ statePaths, count, leaseId } = {}) {
+  withLock(`${statePaths.queue}.lock`, () => {
+    const rows = readQueueRows(statePaths.queue);
+    if (!leaseId) { writeQueueRows(statePaths.queue, rows.slice(count)); return; }
+    const leased = rows.filter((row) => row._leaseId === leaseId).slice(0, count);
+    const keys = new Set(leased.map(queueKey));
+    writeQueueRows(statePaths.queue, rows.filter((row) => !keys.has(queueKey(row))));
   });
 }
 
@@ -309,7 +420,7 @@ export function toOtlpLogs(rows) {
       scopeLogs: [{
         logRecords: rows.map((row) => ({
           body: { stringValue: 'sando.daily_aggregate' },
-          attributes: Object.entries(row).map(([key, value]) => ({ key, value: { stringValue: String(value) } })),
+          attributes: Object.entries(publicRow(row)).map(([key, value]) => ({ key, value: { stringValue: String(value) } })),
         })),
       }],
     }],
@@ -317,30 +428,78 @@ export function toOtlpLogs(rows) {
 }
 
 export function previewNextUpload({ statePaths, endpoint = TELEMETRY_ENDPOINT, max = DEFAULT_BATCH_MAX } = {}) {
-  const rows = loadBatch({ statePaths, max });
+  const rows = loadBatch({ statePaths, max, lease: false });
   return { url: endpoint, headers: { 'content-type': 'application/json' }, body: toOtlpLogs(rows) };
 }
 
-/** Uploads at most one batch. Every failure mode (timeout, network error, non-2xx) is
- *  swallowed and reported as `sent: 0` — telemetry must never throw into, or change the
- *  outcome of, the hook or proxy call that triggered a day close. */
-export async function flushQueue({ statePaths, endpoint = TELEMETRY_ENDPOINT, max = DEFAULT_BATCH_MAX, timeoutMs = 3000 } = {}) {
-  const rows = loadBatch({ statePaths, max });
-  if (rows.length === 0) return { sent: 0 };
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), timeoutMs);
-  try {
-    const response = await fetch(endpoint, {
-      method: 'POST', headers: { 'content-type': 'application/json' },
-      body: JSON.stringify(toOtlpLogs(rows)), signal: controller.signal,
-    });
-    if (!response.ok) return { sent: 0 };
-    ackBatch({ statePaths, count: rows.length });
-    return { sent: rows.length };
-  } catch {
-    return { sent: 0 };
-  } finally {
-    clearTimeout(timer);
+/** Drains eligible batches. Every failure mode is swallowed and reported without
+ * changing the outcome of the hook or proxy call that triggered the flush. */
+function retryAfterMs(response, now) {
+  const value = response.headers?.get?.('retry-after');
+  if (!value) return 0;
+  const seconds = Number(value);
+  if (Number.isFinite(seconds)) return Math.max(0, seconds * 1000);
+  const timestamp = Date.parse(value);
+  return Number.isNaN(timestamp) ? 0 : Math.max(0, timestamp - now);
+}
+
+function updateClaimedRows({ statePaths, leaseId, update }) {
+  withLock(`${statePaths.queue}.lock`, () => {
+    const rows = readQueueRows(statePaths.queue);
+    for (const row of rows) if (row._leaseId === leaseId) update(row);
+    writeQueueRows(statePaths.queue, rows);
+  });
+}
+
+function isRetryableStatus(status) { return [429, 502, 503, 504].includes(status); }
+
+export async function flushQueue({
+  statePaths, endpoint = TELEMETRY_ENDPOINT, max = DEFAULT_BATCH_MAX, timeoutMs = 3000,
+  fetchImpl = fetch, now = Date.now, random = Math.random, sleep = async () => {},
+} = {}) {
+  const result = { sent: 0, rejectedLogRecords: 0 };
+  while (true) {
+    const rows = claimBatch({ statePaths, max, now });
+    if (rows.length === 0) return result;
+    const leaseId = rows[0]._leaseId;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      const response = await fetchImpl(endpoint, {
+        method: 'POST', headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(toOtlpLogs(rows)), signal: controller.signal,
+      });
+      if (response.ok) {
+        let body = {};
+        try { body = await response.json(); } catch { /* empty 2xx body */ }
+        result.rejectedLogRecords += Number(body?.partialSuccess?.rejectedLogRecords || 0);
+        ackBatch({ statePaths, count: rows.length, leaseId });
+        result.sent += rows.length;
+      } else if (isRetryableStatus(response.status)) {
+        updateClaimedRows({ statePaths, leaseId, update: (row) => {
+          const attempt = (row._attemptCount ?? 0) + 1;
+          const base = RETRY_DELAYS_MS[Math.min(attempt - 1, RETRY_DELAYS_MS.length - 1)];
+          row._attemptCount = attempt;
+          row._nextAttemptAt = now() + Math.max(base * random(), retryAfterMs(response, now()));
+          delete row._leaseId; delete row._leaseUntil;
+        }});
+        return result;
+      } else {
+        ackBatch({ statePaths, count: rows.length, leaseId });
+      }
+    } catch {
+      updateClaimedRows({ statePaths, leaseId, update: (row) => {
+        const attempt = (row._attemptCount ?? 0) + 1;
+        const base = RETRY_DELAYS_MS[Math.min(attempt - 1, RETRY_DELAYS_MS.length - 1)];
+        row._attemptCount = attempt;
+        row._nextAttemptAt = now() + base * random();
+        delete row._leaseId; delete row._leaseUntil;
+      }});
+      return result;
+    } finally {
+      clearTimeout(timer);
+    }
+    await sleep(0);
   }
 }
 

--- a/adapters/codex/sando/lib/version.mjs
+++ b/adapters/codex/sando/lib/version.mjs
@@ -1,0 +1,29 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const VERSION_PATTERN = /^\d+\.\d+(?:\.\d+)?$/;
+const STANDALONE_VERSION = '0.2.0';
+const METADATA_FILES = ['package.json', '.claude-plugin/plugin.json', '.codex-plugin/plugin.json'];
+
+function findMetadataFile() {
+  let directory = path.resolve(import.meta.dirname, '..');
+  while (true) {
+    for (const relativePath of METADATA_FILES) {
+      const file = path.join(directory, relativePath);
+      if (fs.existsSync(file)) return file;
+    }
+    const parent = path.dirname(directory);
+    if (parent === directory) break;
+    directory = parent;
+  }
+  return null;
+}
+
+const metadataPath = findMetadataFile();
+const metadata = metadataPath ? JSON.parse(fs.readFileSync(metadataPath, 'utf8')) : { version: STANDALONE_VERSION };
+if (typeof metadata.version !== 'string' || !VERSION_PATTERN.test(metadata.version)) {
+  throw new Error(`Invalid Sando version in ${metadataPath}`);
+}
+
+// Evaluated once per process: no repeated filesystem reads in telemetry paths.
+export const PLUGIN_VERSION = metadata.version;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sando",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "engines": {

--- a/packages/sando/package.json
+++ b/packages/sando/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandoichi",
-  "version": "0.1.6",
+  "version": "0.2.0",
   "description": "Reduce repeated tool-output context in Claude Code and Codex.",
   "license": "MIT",
   "author": "yuzushi",

--- a/packages/sando/src/hook-cli.mjs
+++ b/packages/sando/src/hook-cli.mjs
@@ -6,37 +6,48 @@ import { createReceipt, normalizeEvent, normalizePolicy, optimizeToolOutput } fr
 import { loadProjectRedactionProfile } from './redaction-config.mjs';
 import { defaultMetricsPath, recordMetrics } from './metrics.mjs';
 import {
-  closeFinishedDays, defaultTelemetryConfigPath, defaultTelemetryStatePaths, incrementCounter, readTelemetryConfig,
+  closeFinishedDays, defaultTelemetryConfigPath, defaultTelemetryStatePaths, incrementCounter, isDoNotTrack, readTelemetryConfig, recordActiveDay, recordFailure,
 } from './telemetry.mjs';
-
-const PLUGIN_VERSION = '0.1';
+import { PLUGIN_VERSION } from './version.mjs';
 
 function todayUtc() { return new Date().toISOString().slice(0, 10); }
 
-/** Only counts (never content, paths, or IDs) — see docs/plans/2026-08-25-sando-telemetry-design.md.
- *  `enforce` covers both `apply` and `dry-run`: both walk the real rewrite path, only
- *  `observe` collects without deciding anything. */
+/** Only counts (never content, paths, or IDs). */
 function recordHookTelemetry({ host, env, policy, optimization }) {
-  const configPath = defaultTelemetryConfigPath(env);
-  let config;
-  try { config = readTelemetryConfig(configPath); } catch { return; }
-  if (!config.enabled) return;
   try {
+    const configPath = defaultTelemetryConfigPath(env);
+    const config = readTelemetryConfig(configPath);
+    if (!config.enabled || isDoNotTrack(env)) return;
     const statePaths = defaultTelemetryStatePaths(env);
+    recordActiveDay({ statePaths, day: todayUtc(), pluginVersion: PLUGIN_VERSION, host });
     incrementCounter({
       statePaths,
       day: todayUtc(),
       event: 'hook_summary',
       host,
-      mode: policy.mode === 'observe' ? 'observe' : 'enforce',
+      mode: policy.mode === 'apply' ? 'enforce' : policy.mode === 'dry-run' ? 'dry_run' : 'observe',
       deltas: {
         toolCalls: 1,
         redactions: optimization.stats.redactions,
         cappedOutputs: optimization.artifact ? 1 : 0,
         bytesSaved: Math.max(0, optimization.stats.inputBytes - optimization.stats.inlineBytes),
+        inputTokensSaved: Math.max(0, optimization.stats.estimatedInputTokens - optimization.stats.estimatedInlineTokens),
       },
     });
     closeFinishedDays({ statePaths, configPath, day: todayUtc(), pluginVersion: PLUGIN_VERSION });
+  } catch { /* telemetry is best-effort and must never affect hook output */ }
+}
+
+function recordHookFailure({ host, env, failureStage }) {
+  try {
+    const configPath = defaultTelemetryConfigPath(env);
+    const config = readTelemetryConfig(configPath);
+    if (!config.enabled || isDoNotTrack(env)) return;
+    const statePaths = defaultTelemetryStatePaths(env);
+    const day = todayUtc();
+    recordActiveDay({ statePaths, day, pluginVersion: PLUGIN_VERSION, host });
+    recordFailure({ statePaths, day, event: 'hook_failure_summary', host, failureStage });
+    closeFinishedDays({ statePaths, configPath, day, pluginVersion: PLUGIN_VERSION });
   } catch { /* telemetry is best-effort and must never affect hook output */ }
 }
 
@@ -79,18 +90,23 @@ export function runHookCli({ host, env = process.env } = {}) {
   try {
     policy = hookPolicy(env, host);
   } catch (error) {
+    recordHookFailure({ host, env, failureStage: 'policy' });
     process.stderr.write(`sando invalid policy: ${error instanceof Error ? error.message : 'invalid input'}\n`);
     process.exitCode = 2;
     return;
   }
+  let failureStage = 'input';
   try {
     const input = JSON.parse(fs.readFileSync(0, 'utf8') || '{}');
     const eventName = input.hook_event_name ?? input.hookEventName ?? input.event_name ?? input.eventName;
     if (eventName === 'PostToolUse') {
       const event = normalizeEvent(input);
+      failureStage = 'redaction';
       const redactionProfile = policy.redact ? loadProjectRedactionProfile(event.cwd).profile : undefined;
+      failureStage = 'optimization';
       const optimization = optimizeToolOutput({ toolName: event.toolName, toolInput: event.toolInput, output: event.output, cwd: event.cwd, policy, redactionProfile });
       let shaped;
+      failureStage = 'artifact';
       if (host === 'claude' && policy.mode === 'apply') {
         shaped = shapeForClaude({
           original: event.output,
@@ -101,6 +117,7 @@ export function runHookCli({ host, env = process.env } = {}) {
           policy,
         });
       }
+      failureStage = 'output';
       const receipt = createReceipt({ host, event, optimization, replacement: shaped });
       try {
         recordMetrics({ storagePath: defaultMetricsPath(env), host, event, optimization, receipt });
@@ -120,6 +137,7 @@ export function runHookCli({ host, env = process.env } = {}) {
       }
     }
   } catch (error) {
+    recordHookFailure({ host, env, failureStage });
     if (error?.code === 'SANDO_REDACTION_CONFIG') {
       process.stderr.write(`sando invalid redaction config: ${error.message}\n`);
       process.exitCode = 2;

--- a/packages/sando/src/mcp-server.mjs
+++ b/packages/sando/src/mcp-server.mjs
@@ -1,6 +1,7 @@
 import readline from 'node:readline';
 
 import { optimizeToolOutput } from './core.mjs';
+import { PLUGIN_VERSION } from './version.mjs';
 
 const TOOL = {
   name: 'prepare_tool_output',
@@ -19,7 +20,7 @@ function dispatch(message) {
   if (!message || message.jsonrpc !== '2.0' || typeof message.method !== 'string') return error(message?.id, -32600, 'Invalid Request');
   if (message.id === undefined) return null;
   if (message.method === 'initialize') return response(message.id, {
-    protocolVersion: message.params?.protocolVersion || '2025-06-18', capabilities: { tools: { listChanged: false } }, serverInfo: { name: 'sando', version: '0.1.0' },
+    protocolVersion: message.params?.protocolVersion || '2025-06-18', capabilities: { tools: { listChanged: false } }, serverInfo: { name: 'sando', version: PLUGIN_VERSION },
   });
   if (message.method === 'ping') return response(message.id, {});
   if (message.method === 'tools/list') return response(message.id, { tools: [TOOL] });

--- a/packages/sando/src/postinstall.mjs
+++ b/packages/sando/src/postinstall.mjs
@@ -8,7 +8,7 @@ import readline from 'node:readline/promises';
 import { pathToFileURL } from 'node:url';
 
 import {
-  CONSENT_VERSION, defaultTelemetryConfigPath, enableTelemetry, readTelemetryConfig, TELEMETRY_DETAILS_URL,
+  CONSENT_VERSION, defaultTelemetryConfigPath, enableTelemetry, isDoNotTrack, readTelemetryConfig, TELEMETRY_DETAILS_URL,
 } from './telemetry.mjs';
 
 const CONSENT_PROMPT = `Enable anonymous telemetry? Full details at: ${TELEMETRY_DETAILS_URL} [y/N] `;
@@ -19,6 +19,7 @@ export async function runPostinstall({
 } = {}) {
   try {
     if (env.SANDO_SKIP_TELEMETRY_PROMPT) return;
+    if (isDoNotTrack(env)) return;
     if (!stdin.isTTY || !stdout.isTTY) return; // CI, --ignore-scripts consumers, piped installs, etc.
 
     const configPath = defaultTelemetryConfigPath(env);

--- a/packages/sando/src/proxy.mjs
+++ b/packages/sando/src/proxy.mjs
@@ -4,40 +4,53 @@ import { estimateTokens } from './core.mjs';
 import { detectProviderBody, listSemanticCandidates, transformProviderRequest } from './context-transform.mjs';
 import { recordProxyRequest } from './proxy-metrics.mjs';
 import {
-  closeFinishedDays, defaultTelemetryConfigPath, defaultTelemetryStatePaths, incrementCounter, readTelemetryConfig,
+  closeFinishedDays, defaultTelemetryConfigPath, defaultTelemetryStatePaths, incrementCounter, isDoNotTrack, readTelemetryConfig, recordFailure,
 } from './telemetry.mjs';
-
-const PLUGIN_VERSION = '0.1';
+import { PLUGIN_VERSION } from './version.mjs';
 
 function todayUtc() { return new Date().toISOString().slice(0, 10); }
 
-/** Only counts (never request/response content) — see docs/plans/2026-08-25-sando-telemetry-design.md.
- *  `host` here is the provider request shape (`anthropic`/`openai`), which does not map cleanly to
- *  Sando's `claude`/`codex` telemetry host enum; the proxy fronts both hosts equally, so it reports
- *  under a fixed `claude` label — this is the one place the design doc's host/provider split is
- *  approximate, flagged for the design doc rather than silently assumed. */
-function recordProxyTelemetry({ env, transformed, beforeText, afterText }) {
-  const configPath = defaultTelemetryConfigPath(env);
-  let config;
-  try { config = readTelemetryConfig(configPath); } catch { return; }
-  if (!config.enabled) return;
-  const cacheWarm = transformed.stats.cacheRewriteRatio !== null;
+function telemetryProvider(provider) {
+  if (provider === 'anthropic') return 'anthropic';
+  if (provider === 'openai-chat' || provider === 'openai-responses') return 'openai';
+  return 'unknown';
+}
+
+/** Only counts (never request/response content). */
+function recordProxyTelemetry({ env, provider, transformed, beforeText, afterText }) {
   try {
+    const configPath = defaultTelemetryConfigPath(env);
+    const config = readTelemetryConfig(configPath);
+    if (!config.enabled || isDoNotTrack(env)) return;
     const statePaths = defaultTelemetryStatePaths(env);
     incrementCounter({
       statePaths,
       day: todayUtc(),
       event: 'proxy_summary',
-      host: 'claude',
+      provider: telemetryProvider(provider),
+      mode: 'enforce',
       deltas: {
         rewritesApplied: transformed.changed ? 1 : 0,
         rewritesSkippedCache: transformed.stats.cacheProtectedSkips > 0 ? 1 : 0,
         inputTokensSaved: Math.max(0, estimateTokens(beforeText) - estimateTokens(afterText)),
-        cacheHitYes: cacheWarm ? 1 : 0,
-        cacheHitNo: cacheWarm ? 0 : 1,
       },
     });
     closeFinishedDays({ statePaths, configPath, day: todayUtc(), pluginVersion: PLUGIN_VERSION });
+  } catch { /* telemetry is best-effort and must never affect the proxied response */ }
+}
+
+function recordProxyFailure({ env, provider, failureStage }) {
+  try {
+    const configPath = defaultTelemetryConfigPath(env);
+    const config = readTelemetryConfig(configPath);
+    if (!config.enabled || isDoNotTrack(env)) return;
+    const statePaths = defaultTelemetryStatePaths(env);
+    const day = todayUtc();
+    recordFailure({
+      statePaths, day, event: 'proxy_failure_summary',
+      provider: telemetryProvider(provider), failureStage,
+    });
+    closeFinishedDays({ statePaths, configPath, day, pluginVersion: PLUGIN_VERSION });
   } catch { /* telemetry is best-effort and must never affect the proxied response */ }
 }
 
@@ -176,53 +189,86 @@ export async function createProviderProxy({ upstream, host = '127.0.0.1', port =
   let lastRequestAt = null;
 
   const server = http.createServer(async (request, outgoing) => {
+    let failureProvider = null;
     try {
       if (request.method === 'GET' && new URL(request.url, 'http://sando.invalid').pathname === '/health') {
         jsonResponse(outgoing, 200, { schema: 'sando-provider-proxy/v1', status: 'ok', lastStats });
         return;
       }
-      const rawBody = await readBody(request, maxBodyBytes);
+      let rawBody;
+      try {
+        rawBody = await readBody(request, maxBodyBytes);
+      } catch (error) {
+        recordProxyFailure({ env, provider: null, failureStage: 'input' });
+        if (!outgoing.headersSent) jsonResponse(outgoing, error.message === 'request body exceeds proxy limit' ? 413 : 502, { error: 'sando proxy upstream failure' });
+        else outgoing.destroy();
+        return;
+      }
       let body = rawBody;
       let recordProvider = null;
       let recordModel = null;
       let recordStats = null;
       if (rawBody.length > 0 && /application\/json/i.test(request.headers['content-type'] ?? '')) {
+        let parsed;
         try {
-          const parsed = JSON.parse(rawBody.toString('utf8'));
-          const provider = detectProviderBody(parsed, request.headers);
-          if (provider) {
-            const now = Date.now();
-            const idleMs = lastRequestAt === null ? null : now - lastRequestAt;
-            lastRequestAt = now;
-            const transformed = transformProviderRequest({ provider, body: parsed, policy, idleMs });
-            if (transformed.changed) body = Buffer.from(JSON.stringify(transformed.body));
-            recordProxyTelemetry({
-              env, transformed,
-              beforeText: rawBody.toString('utf8'), afterText: body.toString('utf8'),
-            });
-            lastStats = { provider, ...transformed.stats, changed: transformed.changed, reasons: transformed.reasons };
-            recordProvider = provider;
-            recordModel = typeof parsed?.model === 'string' ? parsed.model : null;
-            recordStats = transformed.stats;
-            if (typeof semanticCompactor === 'function') {
-              const candidates = listSemanticCandidates({ provider, body: transformed.body });
-              const stats = createSemanticStats(candidates);
-              lastStats.semantic = stats;
-              setImmediate(() => observeSemanticCandidates({ provider, candidates, semanticCompactor, stats }));
-            }
-          }
+          parsed = JSON.parse(rawBody.toString('utf8'));
         } catch {
-          body = rawBody;
+          recordProxyFailure({ env, provider: null, failureStage: 'input' });
+        }
+        if (parsed) {
+          const provider = detectProviderBody(parsed, request.headers);
+          failureProvider = provider;
+          try {
+            if (provider) {
+              const now = Date.now();
+              const idleMs = lastRequestAt === null ? null : now - lastRequestAt;
+              lastRequestAt = now;
+              const transformed = transformProviderRequest({ provider, body: parsed, policy, idleMs });
+              if (transformed.changed) body = Buffer.from(JSON.stringify(transformed.body));
+              recordProxyTelemetry({
+                env, provider, transformed,
+                beforeText: rawBody.toString('utf8'), afterText: body.toString('utf8'),
+              });
+              lastStats = { provider, ...transformed.stats, changed: transformed.changed, reasons: transformed.reasons };
+              recordProvider = provider;
+              recordModel = typeof parsed?.model === 'string' ? parsed.model : null;
+              recordStats = transformed.stats;
+              if (typeof semanticCompactor === 'function') {
+                const candidates = listSemanticCandidates({ provider, body: transformed.body });
+                const stats = createSemanticStats(candidates);
+                lastStats.semantic = stats;
+                setImmediate(() => observeSemanticCandidates({ provider, candidates, semanticCompactor, stats }));
+              }
+            }
+          } catch {
+            recordProxyFailure({ env, provider, failureStage: 'optimization' });
+            body = rawBody;
+          }
         }
       }
-      const response = await fetch(targetUrl(upstreamUrl, request.url), {
-        method: request.method,
-        headers: forwardedHeaders(request),
-        body: ['GET', 'HEAD'].includes(request.method) ? undefined : body,
-        redirect: 'manual',
-      });
+      let response;
+      try {
+        response = await fetch(targetUrl(upstreamUrl, request.url), {
+          method: request.method,
+          headers: forwardedHeaders(request),
+          body: ['GET', 'HEAD'].includes(request.method) ? undefined : body,
+          redirect: 'manual',
+        });
+      } catch {
+        recordProxyFailure({ env, provider: failureProvider, failureStage: 'upstream' });
+        if (!outgoing.headersSent) jsonResponse(outgoing, 502, { error: 'sando proxy upstream failure' });
+        else outgoing.destroy();
+        return;
+      }
       let responseText = '';
-      await pipeResponse(response, outgoing, metricsPath ? (chunk) => { responseText += chunk; } : undefined);
+      try {
+        await pipeResponse(response, outgoing, metricsPath ? (chunk) => { responseText += chunk; } : undefined);
+      } catch {
+        recordProxyFailure({ env, provider: failureProvider, failureStage: 'response' });
+        if (!outgoing.headersSent) jsonResponse(outgoing, 502, { error: 'sando proxy upstream failure' });
+        else outgoing.destroy();
+        return;
+      }
       if (metricsPath && recordProvider) {
         try {
           recordProxyRequest({
@@ -232,6 +278,7 @@ export async function createProviderProxy({ upstream, host = '127.0.0.1', port =
         } catch { /* metrics are best-effort and must never affect the proxied response */ }
       }
     } catch (error) {
+      recordProxyFailure({ env, provider: failureProvider, failureStage: 'response' });
       if (!outgoing.headersSent) jsonResponse(outgoing, error.message === 'request body exceeds proxy limit' ? 413 : 502, { error: 'sando proxy upstream failure' });
       else outgoing.destroy();
     }

--- a/packages/sando/src/session-start.mjs
+++ b/packages/sando/src/session-start.mjs
@@ -1,15 +1,27 @@
 import path from 'node:path';
 
-import { defaultTelemetryConfigPath, readTelemetryConfig, TELEMETRY_DETAILS_URL } from './telemetry.mjs';
+import {
+  closeFinishedDays, defaultTelemetryConfigPath, defaultTelemetryStatePaths, isDoNotTrack, readTelemetryConfig, TELEMETRY_DETAILS_URL,
+} from './telemetry.mjs';
+import { PLUGIN_VERSION } from './version.mjs';
 
 export function runSessionStart({
   env = process.env,
   stdout = process.stdout,
   rootEnv = 'PLUGIN_ROOT',
+  spawnImpl,
+  configPath = defaultTelemetryConfigPath(env),
+  statePaths = defaultTelemetryStatePaths(env),
 } = {}) {
   try {
-    const config = readTelemetryConfig(defaultTelemetryConfigPath(env));
-    if (config.prompted_consent_version > 0) {
+    const config = readTelemetryConfig(configPath);
+    if (config.enabled && !isDoNotTrack(env)) {
+      closeFinishedDays({
+        statePaths, configPath, day: new Date().toISOString().slice(0, 10),
+        pluginVersion: PLUGIN_VERSION, ...(spawnImpl ? { spawnImpl } : {}),
+      });
+    }
+    if (isDoNotTrack(env) || config.prompted_consent_version > 0) {
       stdout.write('{}\n');
       return;
     }

--- a/packages/sando/src/telemetry-cli.mjs
+++ b/packages/sando/src/telemetry-cli.mjs
@@ -6,7 +6,7 @@ import { pathToFileURL } from 'node:url';
 
 import {
   defaultTelemetryConfigPath, defaultTelemetryStatePaths,
-  disableTelemetry, enableTelemetry, flushQueue, previewNextUpload, statusTelemetry, TELEMETRY_DETAILS_URL,
+  disableTelemetry, enableTelemetry, flushQueue, isDoNotTrack, previewNextUpload, statusTelemetry, TELEMETRY_DETAILS_URL,
 } from './telemetry.mjs';
 
 const USAGE = 'Usage: sando telemetry <status|enable|disable [--purge]|preview|flush>\n';
@@ -26,13 +26,26 @@ export async function runTelemetryCli({
   try {
     if (command === 'status') {
       const config = statusTelemetry(configPath);
+      if (isDoNotTrack(env)) {
+        stdout.write('telemetry: disabled by DO_NOT_TRACK\n');
+        return { ...config, enabled: false };
+      }
       stdout.write(`telemetry: ${config.enabled ? 'enabled' : 'disabled'}\n`);
       return config;
     }
     if (command === 'enable') {
+      if (isDoNotTrack(env)) {
+        stderr.write('sando telemetry: DO_NOT_TRACK is set; telemetry remains disabled\n');
+        return { ...statusTelemetry(configPath), enabled: false, exitCode: 1 };
+      }
       if (!interactive) {
         stderr.write('sando telemetry: enable requires an interactive session\n');
-        return enableTelemetry({ configPath, interactive: false });
+        return { ...statusTelemetry(configPath), exitCode: 1 };
+      }
+      const current = statusTelemetry(configPath);
+      if (current.enabled) {
+        stdout.write('telemetry already enabled.\n');
+        return current;
       }
       const answer = await prompt(CONSENT_PROMPT);
       const result = enableTelemetry({
@@ -54,6 +67,10 @@ export async function runTelemetryCli({
       return preview;
     }
     if (command === 'flush') {
+      if (isDoNotTrack(env)) {
+        stdout.write('telemetry disabled by DO_NOT_TRACK; nothing to flush.\n');
+        return { sent: 0 };
+      }
       const config = statusTelemetry(configPath);
       if (!config.enabled) {
         stdout.write('telemetry is disabled; nothing to flush.\n');
@@ -72,5 +89,6 @@ export async function runTelemetryCli({
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
-  await runTelemetryCli();
+  const result = await runTelemetryCli();
+  if (result?.exitCode) process.exitCode = result.exitCode;
 }

--- a/packages/sando/src/telemetry-flush-entry.mjs
+++ b/packages/sando/src/telemetry-flush-entry.mjs
@@ -5,19 +5,19 @@
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 
-import { flushQueue, readTelemetryConfig } from './telemetry.mjs';
+import { flushQueue, isDoNotTrack, readTelemetryConfig } from './telemetry.mjs';
 
 function option(argv, name) {
   const index = argv.indexOf(`--${name}`);
   return index === -1 ? undefined : argv[index + 1];
 }
 
-export async function runTelemetryFlushEntry({ argv = process.argv.slice(2) } = {}) {
+export async function runTelemetryFlushEntry({ argv = process.argv.slice(2), env = process.env } = {}) {
   const queuePath = option(argv, 'queue');
   const configPath = option(argv, 'config');
   if (!queuePath || !configPath) throw new Error('telemetry-flush-entry requires --queue and --config');
   const config = readTelemetryConfig(configPath);
-  if (!config.enabled) return { sent: 0 };
+  if (!config.enabled || isDoNotTrack(env)) return { sent: 0 };
   return flushQueue({ statePaths: { queue: queuePath }, endpoint: config.endpoint });
 }
 

--- a/packages/sando/src/telemetry.mjs
+++ b/packages/sando/src/telemetry.mjs
@@ -13,34 +13,54 @@ const MAX_EVENT_BYTES = 2048;
 const COUNT_BUCKETS = ['zero', 'one', '2_to_5', '6_to_20', 'gt_20'];
 const BYTE_BUCKETS = ['lt_4k', '4_to_16k', '16_to_64k', 'gte_64k'];
 const HOSTS = ['claude', 'codex'];
-const MODES = ['enforce', 'observe'];
-const YES_NO_UNKNOWN = ['yes', 'no', 'unknown'];
+const PROVIDERS = ['anthropic', 'openai', 'unknown'];
+const MODES = ['enforce', 'observe', 'dry_run'];
+export const FAILURE_STAGES = [
+  'policy', 'input', 'redaction', 'optimization', 'artifact', 'output', 'upstream', 'response',
+];
 
 const SHARED_FIELDS = {
   schema_version: (value) => value === SCHEMA_VERSION,
-  event: (value) => value === 'hook_summary' || value === 'proxy_summary',
+  event: (value) => [
+    'hook_summary', 'proxy_summary', 'active_day', 'hook_failure_summary', 'proxy_failure_summary',
+  ].includes(value),
   day_utc: (value) => typeof value === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(value),
-  plugin_version: (value) => typeof value === 'string' && /^\d+\.\d+$/.test(value) && value.length <= MAX_STRING_LENGTH,
-  host: (value) => HOSTS.includes(value),
+  plugin_version: (value) => typeof value === 'string' && /^\d+\.\d+(?:\.\d+)?$/.test(value) && value.length <= MAX_STRING_LENGTH,
 };
 
 const HOOK_FIELDS = {
+  host: (value) => HOSTS.includes(value),
   mode: (value) => MODES.includes(value),
   tool_calls_bucket: (value) => COUNT_BUCKETS.includes(value),
-  redactions_bucket: (value) => COUNT_BUCKETS.includes(value),
   capped_outputs_bucket: (value) => COUNT_BUCKETS.includes(value),
   bytes_saved_bucket: (value) => BYTE_BUCKETS.includes(value),
+  input_tokens_saved_bucket: (value) => BYTE_BUCKETS.includes(value),
 };
 
 const PROXY_FIELDS = {
+  provider: (value) => PROVIDERS.includes(value),
+  mode: (value) => MODES.includes(value),
   rewrites_applied_bucket: (value) => COUNT_BUCKETS.includes(value),
   rewrites_skipped_cache_bucket: (value) => COUNT_BUCKETS.includes(value),
   input_tokens_saved_bucket: (value) => BYTE_BUCKETS.includes(value),
-  prompt_cache_hit: (value) => YES_NO_UNKNOWN.includes(value),
+};
+
+const ACTIVE_DAY_FIELDS = { host: (value) => HOSTS.includes(value) };
+const HOOK_FAILURE_FIELDS = {
+  host: (value) => HOSTS.includes(value),
+  failure_stage: (value) => FAILURE_STAGES.includes(value),
+};
+const PROXY_FAILURE_FIELDS = {
+  provider: (value) => PROVIDERS.includes(value),
+  failure_stage: (value) => FAILURE_STAGES.includes(value),
 };
 
 function fieldsForEvent(eventType) {
-  return eventType === 'hook_summary' ? HOOK_FIELDS : PROXY_FIELDS;
+  if (eventType === 'hook_summary') return HOOK_FIELDS;
+  if (eventType === 'proxy_summary') return PROXY_FIELDS;
+  if (eventType === 'active_day') return ACTIVE_DAY_FIELDS;
+  if (eventType === 'hook_failure_summary') return HOOK_FAILURE_FIELDS;
+  return PROXY_FAILURE_FIELDS;
 }
 
 export function countBucket(count) {
@@ -92,6 +112,10 @@ export const TELEMETRY_DETAILS_URL = 'https://github.com/yuzushi-dev/Sando/blob/
 // session-handoff/docs/telemetry-canary-report.md.
 export const TELEMETRY_ENDPOINT = 'https://telemetry.yuzushi.party/v1/logs';
 
+export function isDoNotTrack(env = process.env) {
+  return env.DO_NOT_TRACK !== undefined && env.DO_NOT_TRACK !== '' && env.DO_NOT_TRACK !== '0';
+}
+
 function record(value) { return value !== null && typeof value === 'object' && !Array.isArray(value); }
 
 function emptyTelemetryConfig() {
@@ -140,11 +164,10 @@ export function statusTelemetry(configPath = defaultTelemetryConfigPath()) {
   return readTelemetryConfig(configPath);
 }
 
-/** Only an explicit `yes` in an interactive session enables collection; anything else
- *  (blank, `no`, EOF, or a non-interactive caller) writes the disabled prompt marker so
- *  upgrades and reinstalls never re-prompt or silently opt a user in. */
+/** Only an explicit `yes` in an interactive session enables collection. */
 export function enableTelemetry({ configPath = defaultTelemetryConfigPath(), answer, interactive = true, now = () => new Date() } = {}) {
-  if (!interactive || typeof answer !== 'string' || answer.trim().toLowerCase() !== 'yes') {
+  if (!interactive) return { ...readTelemetryConfig(configPath), exitCode: 1 };
+  if (typeof answer !== 'string' || answer.trim().toLowerCase() !== 'yes') {
     return writeTelemetryConfig(configPath, { schema_version: TELEMETRY_CONFIG_VERSION, enabled: false, prompted_consent_version: CONSENT_VERSION });
   }
   return writeTelemetryConfig(configPath, {
@@ -157,14 +180,21 @@ export function enableTelemetry({ configPath = defaultTelemetryConfigPath(), ans
   });
 }
 
-const QUEUE_MAX_ROWS = 256;
-const QUEUE_MAX_BYTES = 256 * 1024;
+// 30 days of daily aggregates plus activity markers for both supported hosts,
+// with headroom for concurrent event dimensions and temporary outages.
+const QUEUE_MAX_ROWS = 4096;
+const QUEUE_MAX_BYTES = 4 * 1024 * 1024;
+const ACTIVE_DAY_RETENTION_DAYS = 30;
 const DEFAULT_BATCH_MAX = 32;
+const LEASE_MS = 5 * 60 * 1000;
+const RETRY_DELAYS_MS = [60_000, 300_000, 1_800_000, 7_200_000, 21_600_000];
+const CHILD_ENV_KEYS = ['HTTPS_PROXY', 'HTTP_PROXY', 'NO_PROXY', 'NODE_EXTRA_CA_CERTS', 'SSL_CERT_FILE'];
 
-function emptyCounters() { return { schema_version: TELEMETRY_CONFIG_VERSION, counters: {} }; }
+function emptyCounters() { return { schema_version: TELEMETRY_CONFIG_VERSION, counters: {}, active_days: {} }; }
 function readCounters(countersPath) {
   if (!fs.existsSync(countersPath)) return emptyCounters();
-  return JSON.parse(fs.readFileSync(countersPath, 'utf8'));
+  const state = JSON.parse(fs.readFileSync(countersPath, 'utf8'));
+  return { ...state, counters: state.counters ?? {}, active_days: state.active_days ?? {} };
 }
 
 function readQueueRows(queuePath) {
@@ -181,24 +211,29 @@ function writeQueueRows(queuePath, rows) {
   fs.chmodSync(queuePath, 0o600);
 }
 
-/** Enforces the bounded queue (256 rows / 256 KiB), dropping the oldest rows first —
+/** Enforces the bounded queue (4096 rows / 4 MiB), dropping the oldest rows first —
  *  a telemetry backlog must never grow without bound or block product behavior. */
 function appendQueueRows(queuePath, newRows) {
+  ensureDirectory(path.dirname(queuePath));
   withLock(`${queuePath}.lock`, () => {
-    let rows = [...readQueueRows(queuePath), ...newRows];
+    let rows = readQueueRows(queuePath);
+    const keys = new Set(rows.map((row) => queueKey(row)));
+    for (const row of newRows) {
+      if (!keys.has(queueKey(row))) { rows.push(row); keys.add(queueKey(row)); }
+    }
     if (rows.length > QUEUE_MAX_ROWS) rows = rows.slice(rows.length - QUEUE_MAX_ROWS);
     while (rows.length > 0 && Buffer.byteLength(rows.map((row) => JSON.stringify(row)).join('\n')) > QUEUE_MAX_BYTES) rows.shift();
     writeQueueRows(queuePath, rows);
   });
 }
 
-function majorityCacheHit(entry) {
-  const yes = entry.cacheHitYes ?? 0;
-  const no = entry.cacheHitNo ?? 0;
-  const unknown = entry.cacheHitUnknown ?? 0;
-  if (yes > no && yes >= unknown) return 'yes';
-  if (no > yes && no >= unknown) return 'no';
-  return 'unknown';
+function queueKey(row) {
+  return [row.event, row.day_utc, row.plugin_version, row.host ?? row.provider ?? '', row.mode ?? '', row.failureStage ?? row.failure_stage ?? ''].join('|');
+}
+
+function publicRow(row) {
+  const allowed = { ...SHARED_FIELDS, ...fieldsForEvent(row.event) };
+  return Object.fromEntries(Object.entries(row).filter(([key]) => Object.hasOwn(allowed, key)));
 }
 
 function bucketEntry(entry, pluginVersion) {
@@ -207,35 +242,83 @@ function bucketEntry(entry, pluginVersion) {
       schema_version: TELEMETRY_CONFIG_VERSION, event: 'hook_summary', day_utc: entry.day, plugin_version: pluginVersion,
       host: entry.host, mode: entry.mode,
       tool_calls_bucket: countBucket(entry.toolCalls ?? 0),
-      redactions_bucket: countBucket(entry.redactions ?? 0),
       capped_outputs_bucket: countBucket(entry.cappedOutputs ?? 0),
       bytes_saved_bucket: byteBucket(entry.bytesSaved ?? 0),
+      input_tokens_saved_bucket: byteBucket(entry.inputTokensSaved ?? 0),
     };
   }
-  return {
+  if (entry.event === 'proxy_summary') return {
     schema_version: TELEMETRY_CONFIG_VERSION, event: 'proxy_summary', day_utc: entry.day, plugin_version: pluginVersion,
-    host: entry.host,
+    provider: entry.provider ?? 'unknown', mode: entry.mode ?? 'enforce',
     rewrites_applied_bucket: countBucket(entry.rewritesApplied ?? 0),
     rewrites_skipped_cache_bucket: countBucket(entry.rewritesSkippedCache ?? 0),
     input_tokens_saved_bucket: byteBucket(entry.inputTokensSaved ?? 0),
-    prompt_cache_hit: majorityCacheHit(entry),
+  };
+  if (entry.event === 'hook_failure_summary') return {
+    schema_version: TELEMETRY_CONFIG_VERSION, event: 'hook_failure_summary', day_utc: entry.day, plugin_version: pluginVersion,
+    host: entry.host, failure_stage: entry.failureStage,
+  };
+  return {
+    schema_version: TELEMETRY_CONFIG_VERSION, event: 'proxy_failure_summary', day_utc: entry.day, plugin_version: pluginVersion,
+    provider: entry.provider, failure_stage: entry.failureStage,
   };
 }
 
 /** Accumulates raw per-day counts in memory/on disk; values are only bucketed (and thus
  *  only ever leave the machine) once `closeDay` closes a finished UTC day. */
-export function incrementCounter({ statePaths, day, event, host, mode, deltas = {} }) {
-  if (!['hook_summary', 'proxy_summary'].includes(event)) throw new Error('incrementCounter: invalid event');
-  const key = `${day}|${event}|${host}|${mode ?? ''}`;
+export function incrementCounter({ statePaths, day, event, host, provider, mode, failureStage, deltas = {} }) {
+  if (!['hook_summary', 'proxy_summary', 'hook_failure_summary', 'proxy_failure_summary'].includes(event)) {
+    throw new Error('incrementCounter: invalid event');
+  }
+  const isProxy = event.startsWith('proxy_');
+  const dimension = isProxy ? provider : host;
+  const key = event.includes('failure')
+    ? [day, event, dimension, failureStage ?? ''].join('|')
+    : [day, event, dimension, mode ?? ''].join('|');
   ensureDirectory(path.dirname(statePaths.counters));
   withLock(`${statePaths.counters}.lock`, () => {
     const state = readCounters(statePaths.counters);
-    const existing = state.counters[key] ?? { day, event, host, mode: mode ?? null };
+    const existing = state.counters[key] ?? {
+      day, event, ...(isProxy ? { provider: dimension } : { host: dimension }),
+      ...(event.endsWith('_summary') && !event.includes('failure') ? { mode: mode ?? null } : {}),
+      ...(event.includes('failure') ? { failureStage } : {}),
+    };
     for (const [field, value] of Object.entries(deltas)) {
       if (!Number.isInteger(value) || value < 0) throw new Error(`incrementCounter: invalid delta ${field}`);
       existing[field] = (existing[field] ?? 0) + value;
     }
     state.counters[key] = existing;
+    atomicWrite(statePaths.counters, state);
+  });
+}
+
+export function recordFailure({ statePaths, day, event, host, provider, failureStage }) {
+  incrementCounter({
+    statePaths, day, event, host, provider, failureStage, deltas: { count: 1 },
+  });
+}
+
+/** Queues a single non-aggregate activity marker for this UTC day and host. */
+export function recordActiveDay({ statePaths, day, pluginVersion, host }) {
+  const marker = {
+    schema_version: SCHEMA_VERSION, event: 'active_day', day_utc: day, plugin_version: pluginVersion, host,
+  };
+  const validatedMarker = validateEvent(marker);
+  const activeDayKey = `${day}|${host}`;
+  ensureDirectory(path.dirname(statePaths.counters));
+  withLock(`${statePaths.counters}.lock`, () => {
+    const state = readCounters(statePaths.counters);
+    const activeDays = state.active_days;
+    const cutoff = Date.parse(`${day}T00:00:00Z`) - (ACTIVE_DAY_RETENTION_DAYS - 1) * 86_400_000;
+    for (const [key, recordedDay] of Object.entries(activeDays)) {
+      if (Date.parse(`${recordedDay}T00:00:00Z`) < cutoff) delete activeDays[key];
+    }
+    if (Object.hasOwn(activeDays, activeDayKey)) {
+      atomicWrite(statePaths.counters, state);
+      return;
+    }
+    appendQueueRows(statePaths.queue, [validatedMarker]);
+    activeDays[activeDayKey] = day;
     atomicWrite(statePaths.counters, state);
   });
 }
@@ -252,11 +335,11 @@ export function closeDay({ statePaths, day, pluginVersion }) {
       if (entry.day !== day) { remaining[key] = entry; continue; }
       closedRows.push(validateEvent(bucketEntry(entry, pluginVersion)));
     }
+    if (closedRows.length) appendQueueRows(statePaths.queue, closedRows);
     state.counters = remaining;
     ensureDirectory(path.dirname(statePaths.counters));
     atomicWrite(statePaths.counters, state);
   });
-  if (closedRows.length) appendQueueRows(statePaths.queue, closedRows);
   return closedRows;
 }
 
@@ -264,14 +347,16 @@ function launchDetachedFlush({ statePaths, configPath, spawnImpl }) {
   try {
     const entryPath = fileURLToPath(new URL('./telemetry-flush-entry.mjs', import.meta.url));
     const child = spawnImpl(process.execPath, [entryPath, '--queue', statePaths.queue, '--config', configPath], {
-      detached: true, env: {}, stdio: 'ignore', windowsHide: true,
+      detached: true,
+      env: Object.fromEntries(CHILD_ENV_KEYS.filter((key) => process.env[key] !== undefined).map((key) => [key, process.env[key]])),
+      stdio: 'ignore', windowsHide: true,
     });
     child.unref();
   } catch { /* telemetry must never affect the caller */ }
 }
 
-/** Closes every raw counter day before `day` and starts one detached uploader.
- * The child receives only local state paths and an empty environment. */
+/** Closes every raw counter day before `day` and starts one detached uploader
+ * whenever any queue row remains, including a queue from a previous session. */
 export function closeFinishedDays({
   statePaths, configPath = defaultTelemetryConfigPath(), day, pluginVersion,
   spawnImpl = spawn,
@@ -287,18 +372,44 @@ export function closeFinishedDays({
   for (const closedDay of [...days].sort()) {
     closedRows.push(...closeDay({ statePaths, day: closedDay, pluginVersion }));
   }
-  if (closedRows.length) launchDetachedFlush({ statePaths, configPath, spawnImpl });
+  if (fs.existsSync(statePaths.queue) && readQueueRows(statePaths.queue).length) {
+    launchDetachedFlush({ statePaths, configPath, spawnImpl });
+  }
   return closedRows;
 }
 
-export function loadBatch({ statePaths, max = DEFAULT_BATCH_MAX } = {}) {
-  return readQueueRows(statePaths.queue).slice(0, max);
-}
-
-export function ackBatch({ statePaths, count }) {
+function claimBatch({ statePaths, max, now = Date.now, leaseMs = LEASE_MS }) {
+  let claimed = [];
   withLock(`${statePaths.queue}.lock`, () => {
     const rows = readQueueRows(statePaths.queue);
-    writeQueueRows(statePaths.queue, rows.slice(count));
+    const timestamp = now();
+    const available = rows.filter((row) => !row._permanent && (!row._nextAttemptAt || row._nextAttemptAt <= timestamp));
+    if (!available.length) return;
+    if (available.some((row) => row._leaseUntil > timestamp)) return;
+    const leaseId = `${process.pid}-${timestamp}-${Math.random().toString(36).slice(2)}`;
+    const selected = available.slice(0, max);
+    const selectedKeys = new Set(selected.map(queueKey));
+    for (const row of rows) {
+      if (selectedKeys.has(queueKey(row))) { row._leaseId = leaseId; row._leaseUntil = timestamp + leaseMs; }
+    }
+    writeQueueRows(statePaths.queue, rows);
+    claimed = selected.map((row) => ({ ...row, _leaseId: leaseId, _leaseUntil: timestamp + leaseMs }));
+  });
+  return claimed;
+}
+
+export function loadBatch({ statePaths, max = DEFAULT_BATCH_MAX, lease = true, now = Date.now } = {}) {
+  if (lease) return claimBatch({ statePaths, max, now });
+  return readQueueRows(statePaths.queue).filter((row) => !row._permanent && (!row._nextAttemptAt || row._nextAttemptAt <= now())).slice(0, max).map(publicRow);
+}
+
+export function ackBatch({ statePaths, count, leaseId } = {}) {
+  withLock(`${statePaths.queue}.lock`, () => {
+    const rows = readQueueRows(statePaths.queue);
+    if (!leaseId) { writeQueueRows(statePaths.queue, rows.slice(count)); return; }
+    const leased = rows.filter((row) => row._leaseId === leaseId).slice(0, count);
+    const keys = new Set(leased.map(queueKey));
+    writeQueueRows(statePaths.queue, rows.filter((row) => !keys.has(queueKey(row))));
   });
 }
 
@@ -309,7 +420,7 @@ export function toOtlpLogs(rows) {
       scopeLogs: [{
         logRecords: rows.map((row) => ({
           body: { stringValue: 'sando.daily_aggregate' },
-          attributes: Object.entries(row).map(([key, value]) => ({ key, value: { stringValue: String(value) } })),
+          attributes: Object.entries(publicRow(row)).map(([key, value]) => ({ key, value: { stringValue: String(value) } })),
         })),
       }],
     }],
@@ -317,30 +428,78 @@ export function toOtlpLogs(rows) {
 }
 
 export function previewNextUpload({ statePaths, endpoint = TELEMETRY_ENDPOINT, max = DEFAULT_BATCH_MAX } = {}) {
-  const rows = loadBatch({ statePaths, max });
+  const rows = loadBatch({ statePaths, max, lease: false });
   return { url: endpoint, headers: { 'content-type': 'application/json' }, body: toOtlpLogs(rows) };
 }
 
-/** Uploads at most one batch. Every failure mode (timeout, network error, non-2xx) is
- *  swallowed and reported as `sent: 0` — telemetry must never throw into, or change the
- *  outcome of, the hook or proxy call that triggered a day close. */
-export async function flushQueue({ statePaths, endpoint = TELEMETRY_ENDPOINT, max = DEFAULT_BATCH_MAX, timeoutMs = 3000 } = {}) {
-  const rows = loadBatch({ statePaths, max });
-  if (rows.length === 0) return { sent: 0 };
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), timeoutMs);
-  try {
-    const response = await fetch(endpoint, {
-      method: 'POST', headers: { 'content-type': 'application/json' },
-      body: JSON.stringify(toOtlpLogs(rows)), signal: controller.signal,
-    });
-    if (!response.ok) return { sent: 0 };
-    ackBatch({ statePaths, count: rows.length });
-    return { sent: rows.length };
-  } catch {
-    return { sent: 0 };
-  } finally {
-    clearTimeout(timer);
+/** Drains eligible batches. Every failure mode is swallowed and reported without
+ * changing the outcome of the hook or proxy call that triggered the flush. */
+function retryAfterMs(response, now) {
+  const value = response.headers?.get?.('retry-after');
+  if (!value) return 0;
+  const seconds = Number(value);
+  if (Number.isFinite(seconds)) return Math.max(0, seconds * 1000);
+  const timestamp = Date.parse(value);
+  return Number.isNaN(timestamp) ? 0 : Math.max(0, timestamp - now);
+}
+
+function updateClaimedRows({ statePaths, leaseId, update }) {
+  withLock(`${statePaths.queue}.lock`, () => {
+    const rows = readQueueRows(statePaths.queue);
+    for (const row of rows) if (row._leaseId === leaseId) update(row);
+    writeQueueRows(statePaths.queue, rows);
+  });
+}
+
+function isRetryableStatus(status) { return [429, 502, 503, 504].includes(status); }
+
+export async function flushQueue({
+  statePaths, endpoint = TELEMETRY_ENDPOINT, max = DEFAULT_BATCH_MAX, timeoutMs = 3000,
+  fetchImpl = fetch, now = Date.now, random = Math.random, sleep = async () => {},
+} = {}) {
+  const result = { sent: 0, rejectedLogRecords: 0 };
+  while (true) {
+    const rows = claimBatch({ statePaths, max, now });
+    if (rows.length === 0) return result;
+    const leaseId = rows[0]._leaseId;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      const response = await fetchImpl(endpoint, {
+        method: 'POST', headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(toOtlpLogs(rows)), signal: controller.signal,
+      });
+      if (response.ok) {
+        let body = {};
+        try { body = await response.json(); } catch { /* empty 2xx body */ }
+        result.rejectedLogRecords += Number(body?.partialSuccess?.rejectedLogRecords || 0);
+        ackBatch({ statePaths, count: rows.length, leaseId });
+        result.sent += rows.length;
+      } else if (isRetryableStatus(response.status)) {
+        updateClaimedRows({ statePaths, leaseId, update: (row) => {
+          const attempt = (row._attemptCount ?? 0) + 1;
+          const base = RETRY_DELAYS_MS[Math.min(attempt - 1, RETRY_DELAYS_MS.length - 1)];
+          row._attemptCount = attempt;
+          row._nextAttemptAt = now() + Math.max(base * random(), retryAfterMs(response, now()));
+          delete row._leaseId; delete row._leaseUntil;
+        }});
+        return result;
+      } else {
+        ackBatch({ statePaths, count: rows.length, leaseId });
+      }
+    } catch {
+      updateClaimedRows({ statePaths, leaseId, update: (row) => {
+        const attempt = (row._attemptCount ?? 0) + 1;
+        const base = RETRY_DELAYS_MS[Math.min(attempt - 1, RETRY_DELAYS_MS.length - 1)];
+        row._attemptCount = attempt;
+        row._nextAttemptAt = now() + base * random();
+        delete row._leaseId; delete row._leaseUntil;
+      }});
+      return result;
+    } finally {
+      clearTimeout(timer);
+    }
+    await sleep(0);
   }
 }
 

--- a/packages/sando/src/version.mjs
+++ b/packages/sando/src/version.mjs
@@ -1,0 +1,29 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const VERSION_PATTERN = /^\d+\.\d+(?:\.\d+)?$/;
+const STANDALONE_VERSION = '0.2.0';
+const METADATA_FILES = ['package.json', '.claude-plugin/plugin.json', '.codex-plugin/plugin.json'];
+
+function findMetadataFile() {
+  let directory = path.resolve(import.meta.dirname, '..');
+  while (true) {
+    for (const relativePath of METADATA_FILES) {
+      const file = path.join(directory, relativePath);
+      if (fs.existsSync(file)) return file;
+    }
+    const parent = path.dirname(directory);
+    if (parent === directory) break;
+    directory = parent;
+  }
+  return null;
+}
+
+const metadataPath = findMetadataFile();
+const metadata = metadataPath ? JSON.parse(fs.readFileSync(metadataPath, 'utf8')) : { version: STANDALONE_VERSION };
+if (typeof metadata.version !== 'string' || !VERSION_PATTERN.test(metadata.version)) {
+  throw new Error(`Invalid Sando version in ${metadataPath}`);
+}
+
+// Evaluated once per process: no repeated filesystem reads in telemetry paths.
+export const PLUGIN_VERSION = metadata.version;

--- a/packages/sando/tests/bundle-parity.test.mjs
+++ b/packages/sando/tests/bundle-parity.test.mjs
@@ -1,5 +1,8 @@
 import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
 import fs from 'node:fs/promises';
+import fsSync from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
 import { pathToFileURL } from 'node:url';
@@ -23,9 +26,30 @@ test('standalone bundles match canonical routing metadata and behavior', async (
   for (const module of modules.slice(1)) assert.deepEqual(module.optimizeToolOutput(input), expected);
 });
 
-test('generated bundle core, routing, session, and statusline files match canonical sources', async () => {
-  for (const file of ['core.mjs', 'routing.mjs', 'active-session.mjs', 'statusline.mjs', 'redaction-profile.mjs', 'redaction-config.mjs', 'secret-redaction.mjs', 'provider-usage.mjs', 'telemetry.mjs', 'telemetry-cli.mjs', 'telemetry-flush-entry.mjs', 'session-start.mjs']) {
+test('generated bundle core, routing, session, statusline, and version files match canonical sources', async () => {
+  for (const file of ['core.mjs', 'routing.mjs', 'active-session.mjs', 'statusline.mjs', 'redaction-profile.mjs', 'redaction-config.mjs', 'secret-redaction.mjs', 'provider-usage.mjs', 'telemetry.mjs', 'telemetry-cli.mjs', 'telemetry-flush-entry.mjs', 'session-start.mjs', 'version.mjs']) {
     const expected = await fs.readFile(path.join(SOURCE, file), 'utf8');
     for (const directory of BUNDLES) assert.equal(await fs.readFile(path.join(directory, file), 'utf8'), expected);
+  }
+});
+
+test('all installed hook bundles emit the contracted hook telemetry shape', () => {
+  for (const [directory, host] of [['adapters/claude/sando', 'claude'], ['adapters/codex/sando', 'codex'], ['plugins/sando', 'codex']]) {
+    const root = fsSync.mkdtempSync(path.join(os.tmpdir(), 'sando-bundle-hook-'));
+    const configPath = path.join(root, 'config', 'sando', 'telemetry.json');
+    const statePath = path.join(root, 'state', 'sando', 'telemetry-counters.json');
+    fsSync.mkdirSync(path.dirname(configPath), { recursive: true });
+    fsSync.writeFileSync(configPath, JSON.stringify({
+      schema_version: 1, enabled: true, prompted_consent_version: 1, consent_version: 1,
+      consented_at: '2026-08-25T00:00:00.000Z', endpoint: 'http://127.0.0.1:1/v1/logs',
+    }));
+    execFileSync(process.execPath, [path.join(ROOT, directory, 'hooks/post-tool-use.mjs')], {
+      input: JSON.stringify({ hook_event_name: 'PostToolUse', tool_name: 'Bash', tool_response: 'plain output', cwd: root }),
+      env: { ...process.env, XDG_CONFIG_HOME: path.join(root, 'config'), XDG_STATE_HOME: path.join(root, 'state'), SANDO_MODE: 'observe' },
+    });
+    const state = JSON.parse(fsSync.readFileSync(statePath, 'utf8'));
+    const summary = Object.values(state.counters).find((row) => row.event === 'hook_summary');
+    assert.equal(summary.host, host);
+    assert.equal(summary.mode, 'observe');
   }
 });

--- a/packages/sando/tests/hook-cli.test.mjs
+++ b/packages/sando/tests/hook-cli.test.mjs
@@ -97,6 +97,32 @@ test('observe mode maps to the observe telemetry bucket', () => {
   assert.equal(counter.redactions, 0);
 });
 
+test('dry-run mode maps to the dry_run telemetry bucket', () => {
+  const { dir, env, configPath, countersPath } = tempEnv();
+  enableTelemetry(configPath);
+  const script = runnerScript(dir);
+  const input = JSON.stringify({
+    hook_event_name: 'PostToolUse', tool_name: 'Bash', tool_response: 'plain output', cwd: dir,
+  });
+  execFileSync(process.execPath, [script], {
+    input, env: { ...env, SANDO_TEST_HOST: 'claude', SANDO_MODE: 'dry-run' },
+  });
+  assert.equal(firstCounter(countersPath).mode, 'dry_run');
+});
+
+test('invalid hook input records an input failure summary without raw error data', () => {
+  const { dir, env, configPath, countersPath } = tempEnv();
+  enableTelemetry(configPath);
+  const script = runnerScript(dir);
+  execFileSync(process.execPath, [script], {
+    input: '{', env: { ...env, SANDO_TEST_HOST: 'claude' },
+  });
+  const state = JSON.parse(fs.readFileSync(countersPath, 'utf8'));
+  assert.deepEqual(Object.values(state.counters), [{
+    day: Object.values(state.counters)[0].day, event: 'hook_failure_summary', host: 'claude', failureStage: 'input', count: 1,
+  }]);
+});
+
 test('a large output that gets artifacted increments cappedOutputs', () => {
   const { dir, env, configPath, countersPath } = tempEnv();
   enableTelemetry(configPath);
@@ -111,6 +137,18 @@ test('a large output that gets artifacted increments cappedOutputs', () => {
   const counter = firstCounter(countersPath);
   assert.equal(counter.cappedOutputs, 1);
   assert.ok(counter.bytesSaved > 0);
+  assert.ok(counter.inputTokensSaved > 0);
+});
+
+test('invalid hook policy records a policy failure summary', () => {
+  const { dir, env, configPath, countersPath } = tempEnv();
+  enableTelemetry(configPath);
+  const script = runnerScript(dir);
+  assert.throws(() => execFileSync(process.execPath, [script], {
+    input: '{}', env: { ...env, SANDO_TEST_HOST: 'claude', SANDO_POLICY: '{' }, stderr: 'ignore',
+  }));
+  const state = JSON.parse(fs.readFileSync(countersPath, 'utf8'));
+  assert.equal(Object.values(state.counters)[0].failureStage, 'policy');
 });
 
 test('telemetry failure never changes the hook exit code or stdout contract', () => {
@@ -134,5 +172,18 @@ test('a non-PostToolUse event never writes telemetry counters', () => {
   const script = runnerScript(dir);
   const input = JSON.stringify({ hook_event_name: 'PreToolUse', tool_name: 'Bash', tool_response: 'x', cwd: dir });
   execFileSync(process.execPath, [script], { input, env: { ...env, SANDO_TEST_HOST: 'claude' } });
+  assert.equal(fs.existsSync(countersPath), false);
+});
+
+test('DO_NOT_TRACK prevents hook telemetry despite enabled config', () => {
+  const { dir, env, configPath, countersPath } = tempEnv();
+  enableTelemetry(configPath);
+  const script = runnerScript(dir);
+  const input = JSON.stringify({
+    hook_event_name: 'PostToolUse', tool_name: 'Bash', tool_response: 'plain output', cwd: dir,
+  });
+  execFileSync(process.execPath, [script], {
+    input, env: { ...env, SANDO_TEST_HOST: 'claude', DO_NOT_TRACK: '1' },
+  });
   assert.equal(fs.existsSync(countersPath), false);
 });

--- a/packages/sando/tests/postinstall.test.mjs
+++ b/packages/sando/tests/postinstall.test.mjs
@@ -28,12 +28,42 @@ test('non-interactive install (no TTY) never prompts or writes a config', async 
   assert.equal(fs.existsSync(configPath), false);
 });
 
+test('non-interactive install leaves an already decided config byte-for-byte unchanged', async () => {
+  const { xdgConfigHome, configPath } = tempConfigPath();
+  const env = { XDG_CONFIG_HOME: xdgConfigHome };
+  const rl = { question: async () => 'yes', close: () => {} };
+  await runPostinstall({
+    env,
+    stdin: fakeStream({ isTTY: true }),
+    stdout: { ...fakeStream({ isTTY: true }), write: () => {} },
+    readlineFactory: () => rl,
+  });
+  const before = fs.readFileSync(configPath);
+  await runPostinstall({
+    env,
+    stdin: fakeStream({ isTTY: false }),
+    stdout: fakeStream({ isTTY: true }),
+  });
+  assert.deepEqual(fs.readFileSync(configPath), before);
+});
+
 test('SANDO_SKIP_TELEMETRY_PROMPT short-circuits even with a real TTY', async () => {
   const { xdgConfigHome, configPath } = tempConfigPath();
   await runPostinstall({
     env: { SANDO_SKIP_TELEMETRY_PROMPT: '1', XDG_CONFIG_HOME: xdgConfigHome },
     stdin: fakeStream({ isTTY: true }),
     stdout: fakeStream({ isTTY: true }),
+  });
+  assert.equal(fs.existsSync(configPath), false);
+});
+
+test('DO_NOT_TRACK skips the postinstall prompt and does not write config', async () => {
+  const { xdgConfigHome, configPath } = tempConfigPath();
+  await runPostinstall({
+    env: { DO_NOT_TRACK: '1', XDG_CONFIG_HOME: xdgConfigHome },
+    stdin: fakeStream({ isTTY: true }),
+    stdout: fakeStream({ isTTY: true }),
+    readlineFactory: () => { throw new Error('must not prompt'); },
   });
   assert.equal(fs.existsSync(configPath), false);
 });

--- a/packages/sando/tests/proxy-telemetry.test.mjs
+++ b/packages/sando/tests/proxy-telemetry.test.mjs
@@ -102,9 +102,72 @@ test('telemetry enabled: a rewrite increments rewritesApplied and inputTokensSav
 
   const counter = firstCounter(statePaths.counters);
   assert.equal(counter.event, 'proxy_summary');
-  assert.equal(counter.host, 'claude');
+  assert.equal(counter.provider, 'anthropic');
+  assert.equal(counter.mode, 'enforce');
   assert.equal(counter.rewritesApplied, 1);
   assert.ok(counter.inputTokensSaved > 0);
+  assert.deepEqual(JSON.parse(fs.readFileSync(statePaths.counters, 'utf8')).active_days, {});
+});
+
+test('telemetry enabled: an OpenAI Responses request is attributed to openai', async (t) => {
+  const { env, statePaths } = tempTelemetryEnv({ enabled: true });
+  const upstream = http.createServer(async (request, response) => {
+    await readBody(request);
+    response.writeHead(200, { 'content-type': 'application/json' });
+    response.end('{"ok":true}');
+  });
+  const upstreamAddress = await listen(upstream);
+  const proxy = await createProviderProxy({ upstream: `http://127.0.0.1:${upstreamAddress.port}`, env });
+  t.after(async () => { await proxy.close(); await close(upstream); });
+  await fetch(`${proxy.url}/v1/responses`, {
+    method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({
+      model: 'fixture', input: [
+        { type: 'function_call', call_id: 'call-1', name: 'Read', arguments: '{"file_path":"src/app.ts"}' },
+        { type: 'function_call_output', call_id: 'call-1', output: 'file body' },
+      ],
+    }),
+  });
+  const counter = firstCounter(statePaths.counters);
+  assert.equal(counter.provider, 'openai');
+  assert.equal(counter.mode, 'enforce');
+});
+
+test('malformed proxy JSON records an unknown input failure', async (t) => {
+  const { env, statePaths } = tempTelemetryEnv({ enabled: true });
+  const upstream = http.createServer(async (request, response) => {
+    await readBody(request);
+    response.writeHead(200, { 'content-type': 'application/json' });
+    response.end('{"ok":true}');
+  });
+  const upstreamAddress = await listen(upstream);
+  const proxy = await createProviderProxy({ upstream: `http://127.0.0.1:${upstreamAddress.port}`, env });
+  t.after(async () => { await proxy.close(); await close(upstream); });
+  await fetch(`${proxy.url}/v1/messages`, {
+    method: 'POST', headers: { 'content-type': 'application/json' }, body: '{',
+  });
+  const state = JSON.parse(fs.readFileSync(statePaths.counters, 'utf8'));
+  assert.equal(Object.values(state.counters)[0].event, 'proxy_failure_summary');
+  assert.equal(Object.values(state.counters)[0].provider, 'unknown');
+  assert.equal(Object.values(state.counters)[0].failureStage, 'input');
+});
+
+test('an upstream failure records the detected provider and upstream stage', async () => {
+  const { env, statePaths } = tempTelemetryEnv({ enabled: true });
+  const proxy = await createProviderProxy({ upstream: 'http://127.0.0.1:1', env });
+  try {
+    const response = await fetch(`${proxy.url}/v1/messages`, {
+      method: 'POST', headers: { 'content-type': 'application/json', 'anthropic-version': '2023-06-01' },
+      body: JSON.stringify(noChangeFixtureBody()),
+    });
+    assert.equal(response.status, 502);
+  } finally {
+    await proxy.close();
+  }
+  const state = JSON.parse(fs.readFileSync(statePaths.counters, 'utf8'));
+  const failure = Object.values(state.counters).find((row) => row.event === 'proxy_failure_summary');
+  assert.deepEqual(failure, {
+    day: failure.day, event: 'proxy_failure_summary', provider: 'anthropic', failureStage: 'upstream', count: 1,
+  });
 });
 
 test('a recognized request with nothing to rewrite still records a proxy_summary row with zero rewrites', async (t) => {
@@ -170,4 +233,21 @@ test('telemetry failure never affects the proxied response', async (t) => {
 test('readTelemetryConfig sanity: disabled state has enabled === false', () => {
   const { env } = tempTelemetryEnv({ enabled: false });
   assert.equal(readTelemetryConfig(path.join(env.XDG_CONFIG_HOME, 'sando', 'telemetry.json')).enabled, false);
+});
+
+test('DO_NOT_TRACK prevents proxy telemetry despite enabled config', async (t) => {
+  const { env, statePaths } = tempTelemetryEnv({ enabled: true });
+  env.DO_NOT_TRACK = 'true';
+  const upstream = http.createServer(async (request, response) => {
+    await readBody(request);
+    response.writeHead(200, { 'content-type': 'application/json' });
+    response.end('{"ok":true}');
+  });
+  const upstreamAddress = await listen(upstream);
+  const proxy = await createProviderProxy({ upstream: `http://127.0.0.1:${upstreamAddress.port}`, env });
+  t.after(async () => { await proxy.close(); await close(upstream); });
+  await fetch(`${proxy.url}/v1/messages`, {
+    method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(rewriteFixtureBody()),
+  });
+  assert.equal(fs.existsSync(statePaths.counters), false);
 });

--- a/packages/sando/tests/telemetry-cli.test.mjs
+++ b/packages/sando/tests/telemetry-cli.test.mjs
@@ -94,6 +94,63 @@ test('a non-interactive context cannot enable telemetry even with an explicit ye
   assert.match(h.errorOutput(), /interactive/i);
 });
 
+test('non-interactive enable leaves an existing enabled config byte-for-byte unchanged and fails', async () => {
+  const h = harness();
+  await runTelemetryCli({
+    argv: ['enable'], configPath: h.configPath, stdout: h.stdout, stderr: h.stderr,
+    interactive: true, prompt: async () => 'yes',
+  });
+  const before = fs.readFileSync(h.configPath);
+  const result = await runTelemetryCli({
+    argv: ['enable'], configPath: h.configPath, stdout: h.stdout, stderr: h.stderr,
+    interactive: false,
+  });
+  assert.equal(result.exitCode, 1);
+  assert.deepEqual(fs.readFileSync(h.configPath), before);
+});
+
+test('already enabled telemetry does not prompt or rewrite the config', async () => {
+  const h = harness();
+  await runTelemetryCli({
+    argv: ['enable'], configPath: h.configPath, stdout: h.stdout, stderr: h.stderr,
+    interactive: true, prompt: async () => 'yes',
+  });
+  const before = fs.readFileSync(h.configPath);
+  let prompted = false;
+  const result = await runTelemetryCli({
+    argv: ['enable'], configPath: h.configPath, stdout: h.stdout, stderr: h.stderr,
+    interactive: true, prompt: async () => { prompted = true; return ''; },
+  });
+  assert.equal(result.enabled, true);
+  assert.equal(prompted, false);
+  assert.match(h.output(), /already enabled/i);
+  assert.deepEqual(fs.readFileSync(h.configPath), before);
+});
+
+test('DO_NOT_TRACK prevents enable without rewriting config', async () => {
+  const h = harness();
+  let prompted = false;
+  const result = await runTelemetryCli({
+    argv: ['enable'], env: { DO_NOT_TRACK: '1' }, configPath: h.configPath, stdout: h.stdout, stderr: h.stderr,
+    interactive: true, prompt: async () => { prompted = true; return 'yes'; },
+  });
+  assert.equal(prompted, false);
+  assert.equal(result.enabled, false);
+  assert.equal(fs.existsSync(h.configPath), false);
+  assert.match(h.errorOutput(), /DO_NOT_TRACK/);
+});
+
+test('DO_NOT_TRACK prevents flush even when config is enabled', async () => {
+  const h = harness();
+  await runTelemetryCli({ argv: ['enable'], configPath: h.configPath, stdout: h.stdout, stderr: h.stderr, interactive: true, prompt: async () => 'yes' });
+  const result = await runTelemetryCli({
+    argv: ['flush'], env: { DO_NOT_TRACK: '1' }, configPath: h.configPath, statePaths: h.statePaths,
+    stdout: h.stdout, stderr: h.stderr,
+  });
+  assert.equal(result.sent, 0);
+  assert.match(h.output(), /DO_NOT_TRACK/);
+});
+
 test('disable --purge removes counters and queue but keeps the disabled prompt marker', async () => {
   const h = harness();
   fs.mkdirSync(path.dirname(h.statePaths.counters), { recursive: true });

--- a/packages/sando/tests/telemetry-queue.test.mjs
+++ b/packages/sando/tests/telemetry-queue.test.mjs
@@ -8,9 +8,10 @@ import { fileURLToPath } from 'node:url';
 import test from 'node:test';
 
 import {
-  ackBatch, closeDay, closeFinishedDays, flushQueue, incrementCounter, loadBatch, previewNextUpload, toOtlpLogs,
+  ackBatch, closeDay, closeFinishedDays, flushQueue, incrementCounter, loadBatch, previewNextUpload, recordActiveDay, recordFailure, toOtlpLogs,
 } from '../src/telemetry.mjs';
 import { runTelemetryFlushEntry } from '../src/telemetry-flush-entry.mjs';
+import { runSessionStart } from '../src/session-start.mjs';
 
 function tempStatePaths() {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sando-telemetry-queue-'));
@@ -26,7 +27,7 @@ test('incrementCounter accumulates raw counts per day/host/mode and closeDay buc
   assert.deepEqual(closed[0], {
     schema_version: 1, event: 'hook_summary', day_utc: '2026-08-25', plugin_version: '0.5',
     host: 'claude', mode: 'enforce',
-    tool_calls_bucket: '2_to_5', redactions_bucket: 'one', capped_outputs_bucket: 'one', bytes_saved_bucket: '4_to_16k',
+    tool_calls_bucket: '2_to_5', capped_outputs_bucket: 'one', bytes_saved_bucket: '4_to_16k', input_tokens_saved_bucket: 'lt_4k',
   });
 });
 
@@ -38,7 +39,15 @@ test('closeDay removes the closed day from raw counters so it is not double-coun
   assert.deepEqual(again, []);
 });
 
-test('closeFinishedDays closes old counters and launches a detached flush without provider env', () => {
+test('closeDay keeps counters when queue persistence fails', () => {
+  const statePaths = tempStatePaths();
+  incrementCounter({ statePaths, day: '2026-08-25', event: 'hook_summary', host: 'claude', mode: 'enforce', deltas: { toolCalls: 1 } });
+  fs.mkdirSync(statePaths.queue, { recursive: true });
+  assert.throws(() => closeDay({ statePaths, day: '2026-08-25', pluginVersion: '0.5' }));
+  assert.equal(JSON.parse(fs.readFileSync(statePaths.counters, 'utf8')).counters['2026-08-25|hook_summary|claude|enforce'].toolCalls, 1);
+});
+
+test('closeFinishedDays closes old counters and launches a detached flush with only network env', () => {
   const statePaths = tempStatePaths();
   const configPath = path.join(path.dirname(statePaths.counters), 'telemetry.json');
   incrementCounter({ statePaths, day: '2026-08-25', event: 'hook_summary', host: 'claude', mode: 'enforce', deltas: { toolCalls: 1 } });
@@ -54,22 +63,37 @@ test('closeFinishedDays closes old counters and launches a detached flush withou
   assert.equal(invocation.args[0], process.execPath);
   assert.match(invocation.args[1][0], /telemetry-flush-entry\.mjs$/);
   assert.deepEqual(invocation.args[1].slice(1), ['--queue', statePaths.queue, '--config', configPath]);
-  assert.deepEqual(invocation.args[2].env, {});
+  assert.deepEqual(invocation.args[2].env, Object.fromEntries(
+    ['HTTPS_PROXY', 'HTTP_PROXY', 'NO_PROXY', 'NODE_EXTRA_CA_CERTS', 'SSL_CERT_FILE']
+      .filter((key) => process.env[key] !== undefined).map((key) => [key, process.env[key]]),
+  ));
   assert.equal(invocation.args[2].detached, true);
   assert.deepEqual(invocation.args[2].stdio, 'ignore');
   assert.equal(invocation.unref, true);
-  assert.equal(loadBatch({ statePaths }).length, 1);
+  assert.equal(loadBatch({ statePaths, lease: false }).length, 1);
 });
 
-test('closeDay buckets proxy_summary with majority prompt_cache_hit', () => {
+test('closeDay buckets proxy_summary with provider and mode', () => {
   const statePaths = tempStatePaths();
-  incrementCounter({ statePaths, day: '2026-08-25', event: 'proxy_summary', host: 'codex', deltas: { rewritesApplied: 3, rewritesSkippedCache: 1, inputTokensSaved: 20000, cacheHitYes: 2, cacheHitNo: 1 } });
+  incrementCounter({ statePaths, day: '2026-08-25', event: 'proxy_summary', provider: 'openai', mode: 'enforce', deltas: { rewritesApplied: 3, rewritesSkippedCache: 1, inputTokensSaved: 20000 } });
   const closed = closeDay({ statePaths, day: '2026-08-25', pluginVersion: '0.5' });
   assert.deepEqual(closed[0], {
-    schema_version: 1, event: 'proxy_summary', day_utc: '2026-08-25', plugin_version: '0.5', host: 'codex',
+    schema_version: 1, event: 'proxy_summary', day_utc: '2026-08-25', plugin_version: '0.5', provider: 'openai', mode: 'enforce',
     rewrites_applied_bucket: '2_to_5', rewrites_skipped_cache_bucket: 'one',
-    input_tokens_saved_bucket: '16_to_64k', prompt_cache_hit: 'yes',
+    input_tokens_saved_bucket: '16_to_64k',
   });
+});
+
+test('closeDay emits one failure row per host and failure stage without a raw count', () => {
+  const statePaths = tempStatePaths();
+  recordFailure({ statePaths, day: '2026-08-25', event: 'hook_failure_summary', host: 'claude', failureStage: 'optimization' });
+  recordFailure({ statePaths, day: '2026-08-25', event: 'hook_failure_summary', host: 'claude', failureStage: 'optimization' });
+  recordFailure({ statePaths, day: '2026-08-25', event: 'hook_failure_summary', host: 'claude', failureStage: 'input' });
+  const closed = closeDay({ statePaths, day: '2026-08-25', pluginVersion: '0.5' });
+  assert.deepEqual(closed, [
+    { schema_version: 1, event: 'hook_failure_summary', day_utc: '2026-08-25', plugin_version: '0.5', host: 'claude', failure_stage: 'optimization' },
+    { schema_version: 1, event: 'hook_failure_summary', day_utc: '2026-08-25', plugin_version: '0.5', host: 'claude', failure_stage: 'input' },
+  ]);
 });
 
 test('the queue file is created with mode 0600', () => {
@@ -84,16 +108,116 @@ function dayUtc(offset) {
   return new Date(Date.UTC(2026, 0, 1) + offset * 86_400_000).toISOString().slice(0, 10);
 }
 
-test('the queue keeps at most 256 rows, evicting the oldest first', () => {
+test('the queue keeps 4096 rows, evicting the oldest first', () => {
   const statePaths = tempStatePaths();
-  for (let day = 0; day < 260; day += 1) {
-    incrementCounter({ statePaths, day: dayUtc(day), event: 'hook_summary', host: 'claude', mode: 'enforce', deltas: { toolCalls: 1 } });
-    closeDay({ statePaths, day: dayUtc(day), pluginVersion: '0.5' });
-  }
-  const rows = loadBatch({ statePaths, max: 1000 });
-  assert.equal(rows.length, 256);
+  const seedRows = [];
+  for (let day = 0; day < 4099; day += 1) seedRows.push({
+    schema_version: 1, event: 'active_day', day_utc: dayUtc(day), plugin_version: '0.5', host: 'claude',
+  });
+  fs.mkdirSync(path.dirname(statePaths.queue), { recursive: true });
+  fs.writeFileSync(statePaths.queue, `${seedRows.map((row) => JSON.stringify(row)).join('\n')}\n`);
+  incrementCounter({ statePaths, day: dayUtc(4099), event: 'hook_summary', host: 'claude', mode: 'enforce', deltas: { toolCalls: 1 } });
+  closeDay({ statePaths, day: dayUtc(4099), pluginVersion: '0.5' });
+  const rows = loadBatch({ statePaths, max: 10000, lease: false });
+  assert.equal(rows.length, 4096);
   assert.equal(rows[0].day_utc, dayUtc(4));
-  assert.equal(rows[rows.length - 1].day_utc, dayUtc(259));
+  assert.equal(rows[rows.length - 1].day_utc, dayUtc(4099));
+});
+
+test('closeFinishedDays flushes an existing queue even without closing a new day', () => {
+  const statePaths = tempStatePaths();
+  incrementCounter({ statePaths, day: '2026-08-25', event: 'hook_summary', host: 'claude', mode: 'enforce', deltas: { toolCalls: 1 } });
+  closeDay({ statePaths, day: '2026-08-25', pluginVersion: '0.5' });
+  let launches = 0;
+  closeFinishedDays({ statePaths, configPath: '/tmp/config', day: '2026-08-25', pluginVersion: '0.5', spawnImpl: () => { launches += 1; return { unref() {} }; } });
+  assert.equal(launches, 1);
+});
+
+test('session start launches a detached flush for a residual queue', () => {
+  const statePaths = tempStatePaths();
+  incrementCounter({ statePaths, day: '2026-08-25', event: 'hook_summary', host: 'claude', mode: 'enforce', deltas: { toolCalls: 1 } });
+  closeDay({ statePaths, day: '2026-08-25', pluginVersion: '0.5' });
+  const configPath = path.join(path.dirname(statePaths.counters), 'telemetry.json');
+  fs.writeFileSync(configPath, JSON.stringify({ schema_version: 1, enabled: true, prompted_consent_version: 1, consent_version: 1, consented_at: '2026-08-25T00:00:00.000Z', endpoint: 'http://127.0.0.1:1' }));
+  let launches = 0;
+  runSessionStart({ configPath, statePaths, stdout: { write() {} }, spawnImpl: () => { launches += 1; return { unref() {} }; } });
+  assert.equal(launches, 1);
+});
+
+test('recordActiveDay queues one marker per UTC day and host', () => {
+  const statePaths = tempStatePaths();
+  recordActiveDay({ statePaths, day: '2026-08-25', pluginVersion: '0.5', host: 'claude' });
+  recordActiveDay({ statePaths, day: '2026-08-25', pluginVersion: '0.5', host: 'claude' });
+  const rows = loadBatch({ statePaths, max: 100, lease: false });
+  assert.equal(rows.length, 1);
+  assert.deepEqual(toOtlpLogs(rows).resourceLogs[0].scopeLogs[0].logRecords[0].attributes.map((a) => a.key).sort(), ['day_utc', 'event', 'host', 'plugin_version', 'schema_version']);
+  assert.equal(rows[0].event, 'active_day');
+});
+
+test('recordActiveDay stays idempotent after the queue is flushed', () => {
+  const statePaths = tempStatePaths();
+  const marker = { statePaths, day: '2026-08-28', pluginVersion: '0.1', host: 'claude' };
+  recordActiveDay(marker);
+  recordActiveDay(marker);
+  recordActiveDay(marker);
+  assert.equal(loadBatch({ statePaths, lease: false }).length, 1);
+
+  fs.writeFileSync(statePaths.queue, '');
+  recordActiveDay(marker);
+  assert.equal(loadBatch({ statePaths, lease: false }).length, 0);
+});
+
+test('recordActiveDay queues a marker for a different day after a flush', () => {
+  const statePaths = tempStatePaths();
+  const marker = { statePaths, day: '2026-08-28', pluginVersion: '0.1', host: 'claude' };
+  recordActiveDay(marker);
+  fs.writeFileSync(statePaths.queue, '');
+
+  recordActiveDay({ ...marker, day: '2026-08-29' });
+  const rows = loadBatch({ statePaths, lease: false });
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].day_utc, '2026-08-29');
+});
+
+test('loadBatch leases a batch so a second flush cannot claim it', () => {
+  const statePaths = tempStatePaths();
+  incrementCounter({ statePaths, day: '2026-08-25', event: 'hook_summary', host: 'claude', mode: 'enforce', deltas: { toolCalls: 1 } });
+  closeDay({ statePaths, day: '2026-08-25', pluginVersion: '0.5' });
+  const first = loadBatch({ statePaths, lease: true });
+  const second = loadBatch({ statePaths, lease: true });
+  assert.equal(first.length, 1);
+  assert.equal(second.length, 0);
+  ackBatch({ statePaths, count: 1, leaseId: first[0]._leaseId });
+  assert.equal(loadBatch({ statePaths, lease: false }).length, 0);
+});
+
+test('flushQueue persists retry backoff for retryable HTTP failures and honors Retry-After', async () => {
+  const statePaths = tempStatePaths();
+  incrementCounter({ statePaths, day: '2026-08-25', event: 'hook_summary', host: 'claude', mode: 'enforce', deltas: { toolCalls: 1 } });
+  closeDay({ statePaths, day: '2026-08-25', pluginVersion: '0.5' });
+  const result = await flushQueue({
+    statePaths, fetchImpl: async () => new Response('', { status: 503, headers: { 'retry-after': '120' } }),
+    now: () => 1_000_000, random: () => 0, sleep: async () => {},
+  });
+  assert.equal(result.sent, 0);
+  const queued = JSON.parse(fs.readFileSync(statePaths.queue, 'utf8').trim().split('\n')[0]);
+  assert.equal(queued._attemptCount, 1);
+  assert.equal(queued._nextAttemptAt, 1_120_000);
+});
+
+test('flushQueue removes permanent failures without retrying and reports rejected records on 2xx', async () => {
+  const statePaths = tempStatePaths();
+  incrementCounter({ statePaths, day: '2026-08-25', event: 'hook_summary', host: 'claude', mode: 'enforce', deltas: { toolCalls: 1 } });
+  closeDay({ statePaths, day: '2026-08-25', pluginVersion: '0.5' });
+  const permanent = await flushQueue({ statePaths, fetchImpl: async () => new Response('', { status: 400 }), sleep: async () => {} });
+  assert.equal(permanent.sent, 0);
+  assert.equal(loadBatch({ statePaths, lease: false }).length, 0);
+
+  incrementCounter({ statePaths, day: '2026-08-26', event: 'hook_summary', host: 'claude', mode: 'enforce', deltas: { toolCalls: 1 } });
+  closeDay({ statePaths, day: '2026-08-26', pluginVersion: '0.5' });
+  const accepted = await flushQueue({ statePaths, fetchImpl: async () => new Response(JSON.stringify({ partialSuccess: { rejectedLogRecords: 1 } }), { status: 200 }), sleep: async () => {} });
+  assert.equal(accepted.sent, 1);
+  assert.equal(accepted.rejectedLogRecords, 1);
 });
 
 test('loadBatch reads at most 32 rows by default', () => {
@@ -102,7 +226,7 @@ test('loadBatch reads at most 32 rows by default', () => {
     incrementCounter({ statePaths, day: dayUtc(day), event: 'hook_summary', host: 'claude', mode: 'enforce', deltas: { toolCalls: 1 } });
     closeDay({ statePaths, day: dayUtc(day), pluginVersion: '0.5' });
   }
-  const rows = loadBatch({ statePaths });
+  const rows = loadBatch({ statePaths, lease: false });
   assert.equal(rows.length, 32);
 });
 
@@ -114,6 +238,7 @@ test('toOtlpLogs maps rows to an OTLP/HTTP JSON body with service.name=sando', (
   const record = body.resourceLogs[0].scopeLogs[0].logRecords[0];
   assert.equal(record.body.stringValue, 'sando.daily_aggregate');
   assert.ok(record.attributes.some((a) => a.key === 'day_utc' && a.value.stringValue === '2026-08-25'));
+  assert.equal(record.attributes.some((a) => ['redactions_bucket', 'prompt_cache_hit'].includes(a.key)), false);
 });
 
 test('ackBatch removes only the acknowledged rows and keeps the rest', () => {
@@ -122,9 +247,9 @@ test('ackBatch removes only the acknowledged rows and keeps the rest', () => {
   closeDay({ statePaths, day: '2026-08-25', pluginVersion: '0.5' });
   incrementCounter({ statePaths, day: '2026-08-26', event: 'hook_summary', host: 'claude', mode: 'enforce', deltas: { toolCalls: 1 } });
   closeDay({ statePaths, day: '2026-08-26', pluginVersion: '0.5' });
-  const rows = loadBatch({ statePaths });
+  const rows = loadBatch({ statePaths, lease: false });
   ackBatch({ statePaths, count: 1 });
-  const remaining = loadBatch({ statePaths });
+  const remaining = loadBatch({ statePaths, lease: false });
   assert.equal(remaining.length, 1);
   assert.equal(remaining[0].day_utc, rows[1].day_utc);
 });
@@ -136,7 +261,7 @@ test('previewNextUpload renders the exact next OTLP body and header names withou
   const preview = previewNextUpload({ statePaths, endpoint: 'https://telemetry.example/v1/logs' });
   assert.deepEqual(Object.keys(preview.headers).sort(), ['content-type']);
   assert.equal(preview.headers['content-type'], 'application/json');
-  assert.deepEqual(preview.body, toOtlpLogs(loadBatch({ statePaths })));
+  assert.deepEqual(preview.body, toOtlpLogs(loadBatch({ statePaths, lease: false })));
   assert.equal(preview.url, 'https://telemetry.example/v1/logs');
 });
 
@@ -160,7 +285,7 @@ test('flushQueue posts the batch over HTTPS-shaped fetch and acks on success, le
     const result = await flushQueue({ statePaths, endpoint: `http://127.0.0.1:${port}/v1/logs`, timeoutMs: 3000 });
     assert.equal(result.sent, 1);
     assert.ok(received);
-    assert.equal(loadBatch({ statePaths }).length, 0);
+    assert.equal(loadBatch({ statePaths, lease: false }).length, 0);
   } finally {
     await new Promise((resolve) => server.close(resolve));
   }
@@ -172,7 +297,7 @@ test('flushQueue leaves the queue intact when the upload fails', async () => {
   closeDay({ statePaths, day: '2026-08-25', pluginVersion: '0.5' });
   const result = await flushQueue({ statePaths, endpoint: 'http://127.0.0.1:1/v1/logs', timeoutMs: 500 });
   assert.equal(result.sent, 0);
-  assert.equal(loadBatch({ statePaths }).length, 1);
+  assert.equal(fs.readFileSync(statePaths.queue, 'utf8').trim().length > 0, true);
 });
 
 test('flushQueue does nothing and never throws on an empty queue', async () => {
@@ -199,7 +324,7 @@ test('the detached flush entrypoint is a no-op when telemetry is disabled, with 
   const entryPath = fileURLToPath(new URL('../src/telemetry-flush-entry.mjs', import.meta.url));
   // Fully empty environment — no PATH, no HOME, no provider credentials. Only argv is read.
   execFileSync(process.execPath, [entryPath, '--queue', statePaths.queue, '--config', configPath], { env: {} });
-  assert.equal(loadBatch({ statePaths }).length, 1, 'disabled telemetry must not touch the queue');
+  assert.equal(loadBatch({ statePaths, lease: false }).length, 1, 'disabled telemetry must not touch the queue');
 });
 
 test('the detached flush entrypoint flushes the queue in-process when telemetry is enabled', async () => {
@@ -224,5 +349,5 @@ test('the detached flush entrypoint flushes the queue in-process when telemetry 
   } finally {
     await new Promise((resolve) => server.close(resolve));
   }
-  assert.equal(loadBatch({ statePaths }).length, 0);
+  assert.equal(loadBatch({ statePaths, lease: false }).length, 0);
 });

--- a/packages/sando/tests/telemetry.test.mjs
+++ b/packages/sando/tests/telemetry.test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { countBucket, byteBucket, serializeEvent, validateEvent } from '../src/telemetry.mjs';
+import { countBucket, byteBucket, FAILURE_STAGES, isDoNotTrack, serializeEvent, validateEvent } from '../src/telemetry.mjs';
 
 function hookEvent(overrides = {}) {
   return {
@@ -12,9 +12,9 @@ function hookEvent(overrides = {}) {
     host: 'claude',
     mode: 'enforce',
     tool_calls_bucket: '6_to_20',
-    redactions_bucket: 'one',
     capped_outputs_bucket: 'zero',
     bytes_saved_bucket: '16_to_64k',
+    input_tokens_saved_bucket: '4_to_16k',
     ...overrides,
   };
 }
@@ -25,11 +25,11 @@ function proxyEvent(overrides = {}) {
     event: 'proxy_summary',
     day_utc: '2026-08-25',
     plugin_version: '0.5',
-    host: 'claude',
+    provider: 'openai',
+    mode: 'enforce',
     rewrites_applied_bucket: '2_to_5',
     rewrites_skipped_cache_bucket: 'one',
     input_tokens_saved_bucket: '16_to_64k',
-    prompt_cache_hit: 'yes',
     ...overrides,
   };
 }
@@ -55,12 +55,38 @@ test('byteBucket maps byte counts to the fixed enum', () => {
   assert.throws(() => byteBucket(-1), /invalid/);
 });
 
+test('DO_NOT_TRACK treats only non-empty values other than 0 as enabled', () => {
+  assert.equal(isDoNotTrack({}), false);
+  assert.equal(isDoNotTrack({ DO_NOT_TRACK: '' }), false);
+  assert.equal(isDoNotTrack({ DO_NOT_TRACK: '0' }), false);
+  assert.equal(isDoNotTrack({ DO_NOT_TRACK: '1' }), true);
+});
+
 test('validateEvent accepts a well-formed hook_summary event', () => {
   assert.doesNotThrow(() => validateEvent(hookEvent()));
 });
 
 test('validateEvent accepts a well-formed proxy_summary event', () => {
   assert.doesNotThrow(() => validateEvent(proxyEvent()));
+});
+
+test('validateEvent accepts failure summaries and the dry_run mode', () => {
+  assert.equal(FAILURE_STAGES.length, 8);
+  assert.doesNotThrow(() => validateEvent({
+    schema_version: 1, event: 'hook_failure_summary', day_utc: '2026-08-25', plugin_version: '0.5',
+    host: 'codex', failure_stage: 'input',
+  }));
+  assert.doesNotThrow(() => validateEvent({
+    schema_version: 1, event: 'proxy_failure_summary', day_utc: '2026-08-25', plugin_version: '0.5',
+    provider: 'unknown', failure_stage: 'input',
+  }));
+  assert.doesNotThrow(() => validateEvent(hookEvent({ mode: 'dry_run' })));
+});
+
+test('validateEvent accepts the privacy-preserving active_day marker', () => {
+  assert.doesNotThrow(() => validateEvent({
+    schema_version: 1, event: 'active_day', day_utc: '2026-08-25', plugin_version: '0.5', host: 'claude',
+  }));
 });
 
 test('validateEvent rejects an unknown event type', () => {
@@ -70,8 +96,10 @@ test('validateEvent rejects an unknown event type', () => {
 test('validateEvent rejects an unknown enum value', () => {
   assert.throws(() => validateEvent(hookEvent({ host: 'gemini' })), /host/);
   assert.throws(() => validateEvent(hookEvent({ mode: 'apply' })), /mode/);
-  assert.throws(() => validateEvent(hookEvent({ redactions_bucket: 'many' })), /redactions_bucket/);
-  assert.throws(() => validateEvent(proxyEvent({ prompt_cache_hit: 'maybe' })), /prompt_cache_hit/);
+  assert.throws(() => validateEvent(hookEvent({ redactions_bucket: 'one' })), /unknown field/);
+  assert.throws(() => validateEvent(proxyEvent({ provider: 'claude' })), /provider/);
+  assert.throws(() => validateEvent(proxyEvent({ host: 'claude' })), /unknown field/);
+  assert.throws(() => validateEvent(proxyEvent({ prompt_cache_hit: 'yes' })), /unknown field/);
 });
 
 test('validateEvent rejects unknown fields', () => {
@@ -91,9 +119,10 @@ test('validateEvent rejects strings over 32 characters', () => {
   assert.throws(() => validateEvent(hookEvent({ plugin_version: '0.5'.padEnd(33, '0') })), /plugin_version/);
 });
 
-test('validateEvent rejects a prerelease or patch plugin_version', () => {
-  assert.throws(() => validateEvent(hookEvent({ plugin_version: '0.5.1' })), /plugin_version/);
+test('validateEvent accepts stable patch plugin versions and rejects prereleases', () => {
+  assert.doesNotThrow(() => validateEvent(hookEvent({ plugin_version: '0.5.1' })));
   assert.throws(() => validateEvent(hookEvent({ plugin_version: '0.5.0-rc1' })), /plugin_version/);
+  assert.throws(() => validateEvent(hookEvent({ plugin_version: '0.5.x' })), /plugin_version/);
 });
 
 test('validateEvent rejects a day_utc with a time component', () => {

--- a/packages/sando/tests/version-consistency.test.mjs
+++ b/packages/sando/tests/version-consistency.test.mjs
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+
+const ROOT = path.resolve(import.meta.dirname, '../../..');
+const VERSION_SOURCES = [
+  ['package.json', ['version']],
+  ['packages/sando/package.json', ['version']],
+  ['adapters/claude/sando/.claude-plugin/plugin.json', ['version']],
+  ['adapters/claude/sando/.claude-plugin/marketplace.json', ['plugins', 0, 'version']],
+  ['plugins/sando/.codex-plugin/plugin.json', ['version']],
+  ['plugins/sando/.agents/plugins/marketplace.json', ['metadata', 'version']],
+];
+
+function readField(relativePath, fieldPath) {
+  return fieldPath.reduce((value, key) => value[key], JSON.parse(fs.readFileSync(path.join(ROOT, relativePath), 'utf8')));
+}
+
+test('all local Sando release metadata uses the package version', () => {
+  const [canonicalPath, canonicalField] = VERSION_SOURCES[1];
+  const canonical = readField(canonicalPath, canonicalField);
+  const observed = VERSION_SOURCES.map(([relativePath, fieldPath]) => ({
+    path: relativePath,
+    version: readField(relativePath, fieldPath),
+  }));
+
+  assert.deepEqual(observed, observed.map((entry) => ({ ...entry, version: canonical })));
+});
+
+test('telemetry entrypoints use the shared runtime version module', () => {
+  const entrypoints = [
+    'packages/sando/src/hook-cli.mjs',
+    'packages/sando/src/proxy.mjs',
+    'packages/sando/src/session-start.mjs',
+    'adapters/claude/sando/lib/session-start.mjs',
+    'adapters/codex/sando/lib/session-start.mjs',
+    'plugins/sando/lib/session-start.mjs',
+    'packages/sando/src/mcp-server.mjs',
+    'adapters/claude/sando/lib/mcp-server.mjs',
+    'adapters/claude/sando/lib/mcp-entry.mjs',
+    'adapters/codex/sando/lib/mcp-server.mjs',
+    'adapters/codex/sando/lib/mcp-entry.mjs',
+    'plugins/sando/lib/mcp-server.mjs',
+    'plugins/sando/lib/mcp-entry.mjs',
+  ];
+
+  for (const relativePath of entrypoints) {
+    const source = fs.readFileSync(path.join(ROOT, relativePath), 'utf8');
+    assert.match(source, /from ['"]\.\/version\.mjs['"]/);
+    assert.doesNotMatch(source, /PLUGIN_VERSION\s*=\s*['"]/);
+  }
+});

--- a/plugins/sando/.agents/plugins/marketplace.json
+++ b/plugins/sando/.agents/plugins/marketplace.json
@@ -3,7 +3,7 @@
   "interface": { "displayName": "Sando" },
   "metadata": {
     "description": "Reduce repeated tool-output context in Codex.",
-    "version": "0.1.3"
+    "version": "0.2.0"
   },
   "plugins": [
     {

--- a/plugins/sando/.codex-plugin/plugin.json
+++ b/plugins/sando/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sando",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "Reduce repeated tool-output context in Codex.",
   "author": {
     "name": "Sando contributors"

--- a/plugins/sando/lib/hook-entry.mjs
+++ b/plugins/sando/lib/hook-entry.mjs
@@ -5,6 +5,47 @@ import path from 'node:path';
 import { createReceipt, normalizeEvent, normalizePolicy, optimizeToolOutput } from './core.mjs';
 import { defaultMetricsPath, recordMetrics } from './metrics.mjs';
 import { loadProjectRedactionProfile } from './redaction-config.mjs';
+import {
+  closeFinishedDays, defaultTelemetryConfigPath, defaultTelemetryStatePaths, incrementCounter, isDoNotTrack, readTelemetryConfig, recordActiveDay, recordFailure,
+} from './telemetry.mjs';
+import { PLUGIN_VERSION } from './version.mjs';
+
+function todayUtc() { return new Date().toISOString().slice(0, 10); }
+
+function recordHookTelemetry({ host, env, policy, optimization }) {
+  try {
+    const configPath = defaultTelemetryConfigPath(env);
+    const config = readTelemetryConfig(configPath);
+    if (!config.enabled || isDoNotTrack(env)) return;
+    const statePaths = defaultTelemetryStatePaths(env);
+    const day = todayUtc();
+    recordActiveDay({ statePaths, day, pluginVersion: PLUGIN_VERSION, host });
+    incrementCounter({
+      statePaths, day, event: 'hook_summary', host,
+      mode: policy.mode === 'apply' ? 'enforce' : policy.mode === 'dry-run' ? 'dry_run' : 'observe',
+      deltas: {
+        toolCalls: 1, redactions: optimization.stats.redactions,
+        cappedOutputs: optimization.artifact ? 1 : 0,
+        bytesSaved: Math.max(0, optimization.stats.inputBytes - optimization.stats.inlineBytes),
+        inputTokensSaved: Math.max(0, optimization.stats.estimatedInputTokens - optimization.stats.estimatedInlineTokens),
+      },
+    });
+    closeFinishedDays({ statePaths, configPath, day, pluginVersion: PLUGIN_VERSION });
+  } catch { /* telemetry is best-effort */ }
+}
+
+function recordHookFailure({ host, env, failureStage }) {
+  try {
+    const configPath = defaultTelemetryConfigPath(env);
+    const config = readTelemetryConfig(configPath);
+    if (!config.enabled || isDoNotTrack(env)) return;
+    const statePaths = defaultTelemetryStatePaths(env);
+    const day = todayUtc();
+    recordActiveDay({ statePaths, day, pluginVersion: PLUGIN_VERSION, host });
+    recordFailure({ statePaths, day, event: 'hook_failure_summary', host, failureStage });
+    closeFinishedDays({ statePaths, configPath, day, pluginVersion: PLUGIN_VERSION });
+  } catch { /* telemetry is best-effort */ }
+}
 
 function hookPolicy(env) {
   const policy = env.SANDO_POLICY
@@ -45,20 +86,27 @@ export function runHookCli({ host, env = process.env } = {}) {
   try {
     policy = hookPolicy(env);
   } catch (error) {
+    recordHookFailure({ host, env, failureStage: 'policy' });
     process.stderr.write(`sando invalid policy: ${error instanceof Error ? error.message : 'invalid input'}\n`);
     process.exitCode = 2;
     return;
   }
+  let failureStage = 'input';
   try {
     const input = JSON.parse(fs.readFileSync(0, 'utf8') || '{}');
     const eventName = input.hook_event_name ?? input.hookEventName ?? input.event_name ?? input.eventName;
     if (eventName === 'PostToolUse') {
       const event = normalizeEvent(input);
+      failureStage = 'redaction';
       const redactionProfile = policy.redact ? loadProjectRedactionProfile(event.cwd).profile : undefined;
+      failureStage = 'optimization';
       const optimization = optimizeToolOutput({ toolName: event.toolName, toolInput: event.toolInput, output: event.output, cwd: event.cwd, policy, redactionProfile });
+      failureStage = 'output';
       const receipt = createReceipt({ host, event, optimization });
       try { recordMetrics({ storagePath: defaultMetricsPath(env), host, event, optimization, receipt }); } catch {}
+      recordHookTelemetry({ host, env, policy, optimization });
       if (host === 'claude' && policy.mode === 'apply') {
+        failureStage = 'artifact';
         const shaped = shapeForClaude({
           original: event.output,
           optimization,
@@ -77,6 +125,7 @@ export function runHookCli({ host, env = process.env } = {}) {
       }
     }
   } catch (error) {
+    recordHookFailure({ host, env, failureStage });
     if (error?.code === 'SANDO_REDACTION_CONFIG') {
       process.stderr.write(`sando invalid redaction config: ${error.message}\n`);
       process.exitCode = 2;

--- a/plugins/sando/lib/mcp-entry.mjs
+++ b/plugins/sando/lib/mcp-entry.mjs
@@ -1,6 +1,7 @@
 import readline from 'node:readline';
 
 import { callMcpToolAsync, MCP_TOOLS } from './mcp-tools.mjs';
+import { PLUGIN_VERSION } from './version.mjs';
 
 function response(id, result) { return { jsonrpc: '2.0', id, result }; }
 function error(id, code, message) { return { jsonrpc: '2.0', id: id ?? null, error: { code, message } }; }
@@ -13,7 +14,7 @@ async function dispatch(message, active) {
   }
   if (message.id === undefined) return null;
   if (message.method === 'initialize') return response(message.id, {
-    protocolVersion: message.params?.protocolVersion || '2025-06-18', capabilities: { tools: { listChanged: false }, experimental: { 'codex/sandbox-state-meta': {} } }, serverInfo: { name: 'sando', version: '0.1.0' },
+    protocolVersion: message.params?.protocolVersion || '2025-06-18', capabilities: { tools: { listChanged: false }, experimental: { 'codex/sandbox-state-meta': {} } }, serverInfo: { name: 'sando', version: PLUGIN_VERSION },
   });
   if (message.method === 'ping') return response(message.id, {});
   if (message.method === 'tools/list') return response(message.id, { tools: MCP_TOOLS });

--- a/plugins/sando/lib/mcp-server.mjs
+++ b/plugins/sando/lib/mcp-server.mjs
@@ -1,6 +1,7 @@
 import readline from 'node:readline';
 
 import { optimizeToolOutput } from './core.mjs';
+import { PLUGIN_VERSION } from './version.mjs';
 
 const TOOL = {
   name: 'prepare_tool_output',
@@ -13,7 +14,7 @@ function error(id, code, message) { return { jsonrpc: '2.0', id: id ?? null, err
 function dispatch(message) {
   if (!message || message.jsonrpc !== '2.0' || typeof message.method !== 'string') return error(message?.id, -32600, 'Invalid Request');
   if (message.id === undefined) return null;
-  if (message.method === 'initialize') return response(message.id, { protocolVersion: message.params?.protocolVersion || '2025-06-18', capabilities: { tools: { listChanged: false } }, serverInfo: { name: 'sando', version: '0.1.0' } });
+  if (message.method === 'initialize') return response(message.id, { protocolVersion: message.params?.protocolVersion || '2025-06-18', capabilities: { tools: { listChanged: false } }, serverInfo: { name: 'sando', version: PLUGIN_VERSION } });
   if (message.method === 'ping') return response(message.id, {});
   if (message.method === 'tools/list') return response(message.id, { tools: [TOOL] });
   if (message.method === 'tools/call') {

--- a/plugins/sando/lib/session-start.mjs
+++ b/plugins/sando/lib/session-start.mjs
@@ -1,15 +1,27 @@
 import path from 'node:path';
 
-import { defaultTelemetryConfigPath, readTelemetryConfig, TELEMETRY_DETAILS_URL } from './telemetry.mjs';
+import {
+  closeFinishedDays, defaultTelemetryConfigPath, defaultTelemetryStatePaths, isDoNotTrack, readTelemetryConfig, TELEMETRY_DETAILS_URL,
+} from './telemetry.mjs';
+import { PLUGIN_VERSION } from './version.mjs';
 
 export function runSessionStart({
   env = process.env,
   stdout = process.stdout,
   rootEnv = 'PLUGIN_ROOT',
+  spawnImpl,
+  configPath = defaultTelemetryConfigPath(env),
+  statePaths = defaultTelemetryStatePaths(env),
 } = {}) {
   try {
-    const config = readTelemetryConfig(defaultTelemetryConfigPath(env));
-    if (config.prompted_consent_version > 0) {
+    const config = readTelemetryConfig(configPath);
+    if (config.enabled && !isDoNotTrack(env)) {
+      closeFinishedDays({
+        statePaths, configPath, day: new Date().toISOString().slice(0, 10),
+        pluginVersion: PLUGIN_VERSION, ...(spawnImpl ? { spawnImpl } : {}),
+      });
+    }
+    if (isDoNotTrack(env) || config.prompted_consent_version > 0) {
       stdout.write('{}\n');
       return;
     }

--- a/plugins/sando/lib/telemetry-cli.mjs
+++ b/plugins/sando/lib/telemetry-cli.mjs
@@ -6,7 +6,7 @@ import { pathToFileURL } from 'node:url';
 
 import {
   defaultTelemetryConfigPath, defaultTelemetryStatePaths,
-  disableTelemetry, enableTelemetry, flushQueue, previewNextUpload, statusTelemetry, TELEMETRY_DETAILS_URL,
+  disableTelemetry, enableTelemetry, flushQueue, isDoNotTrack, previewNextUpload, statusTelemetry, TELEMETRY_DETAILS_URL,
 } from './telemetry.mjs';
 
 const USAGE = 'Usage: sando telemetry <status|enable|disable [--purge]|preview|flush>\n';
@@ -26,13 +26,26 @@ export async function runTelemetryCli({
   try {
     if (command === 'status') {
       const config = statusTelemetry(configPath);
+      if (isDoNotTrack(env)) {
+        stdout.write('telemetry: disabled by DO_NOT_TRACK\n');
+        return { ...config, enabled: false };
+      }
       stdout.write(`telemetry: ${config.enabled ? 'enabled' : 'disabled'}\n`);
       return config;
     }
     if (command === 'enable') {
+      if (isDoNotTrack(env)) {
+        stderr.write('sando telemetry: DO_NOT_TRACK is set; telemetry remains disabled\n');
+        return { ...statusTelemetry(configPath), enabled: false, exitCode: 1 };
+      }
       if (!interactive) {
         stderr.write('sando telemetry: enable requires an interactive session\n');
-        return enableTelemetry({ configPath, interactive: false });
+        return { ...statusTelemetry(configPath), exitCode: 1 };
+      }
+      const current = statusTelemetry(configPath);
+      if (current.enabled) {
+        stdout.write('telemetry already enabled.\n');
+        return current;
       }
       const answer = await prompt(CONSENT_PROMPT);
       const result = enableTelemetry({
@@ -54,6 +67,10 @@ export async function runTelemetryCli({
       return preview;
     }
     if (command === 'flush') {
+      if (isDoNotTrack(env)) {
+        stdout.write('telemetry disabled by DO_NOT_TRACK; nothing to flush.\n');
+        return { sent: 0 };
+      }
       const config = statusTelemetry(configPath);
       if (!config.enabled) {
         stdout.write('telemetry is disabled; nothing to flush.\n');
@@ -72,5 +89,6 @@ export async function runTelemetryCli({
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
-  await runTelemetryCli();
+  const result = await runTelemetryCli();
+  if (result?.exitCode) process.exitCode = result.exitCode;
 }

--- a/plugins/sando/lib/telemetry-flush-entry.mjs
+++ b/plugins/sando/lib/telemetry-flush-entry.mjs
@@ -5,19 +5,19 @@
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 
-import { flushQueue, readTelemetryConfig } from './telemetry.mjs';
+import { flushQueue, isDoNotTrack, readTelemetryConfig } from './telemetry.mjs';
 
 function option(argv, name) {
   const index = argv.indexOf(`--${name}`);
   return index === -1 ? undefined : argv[index + 1];
 }
 
-export async function runTelemetryFlushEntry({ argv = process.argv.slice(2) } = {}) {
+export async function runTelemetryFlushEntry({ argv = process.argv.slice(2), env = process.env } = {}) {
   const queuePath = option(argv, 'queue');
   const configPath = option(argv, 'config');
   if (!queuePath || !configPath) throw new Error('telemetry-flush-entry requires --queue and --config');
   const config = readTelemetryConfig(configPath);
-  if (!config.enabled) return { sent: 0 };
+  if (!config.enabled || isDoNotTrack(env)) return { sent: 0 };
   return flushQueue({ statePaths: { queue: queuePath }, endpoint: config.endpoint });
 }
 

--- a/plugins/sando/lib/telemetry.mjs
+++ b/plugins/sando/lib/telemetry.mjs
@@ -13,34 +13,54 @@ const MAX_EVENT_BYTES = 2048;
 const COUNT_BUCKETS = ['zero', 'one', '2_to_5', '6_to_20', 'gt_20'];
 const BYTE_BUCKETS = ['lt_4k', '4_to_16k', '16_to_64k', 'gte_64k'];
 const HOSTS = ['claude', 'codex'];
-const MODES = ['enforce', 'observe'];
-const YES_NO_UNKNOWN = ['yes', 'no', 'unknown'];
+const PROVIDERS = ['anthropic', 'openai', 'unknown'];
+const MODES = ['enforce', 'observe', 'dry_run'];
+export const FAILURE_STAGES = [
+  'policy', 'input', 'redaction', 'optimization', 'artifact', 'output', 'upstream', 'response',
+];
 
 const SHARED_FIELDS = {
   schema_version: (value) => value === SCHEMA_VERSION,
-  event: (value) => value === 'hook_summary' || value === 'proxy_summary',
+  event: (value) => [
+    'hook_summary', 'proxy_summary', 'active_day', 'hook_failure_summary', 'proxy_failure_summary',
+  ].includes(value),
   day_utc: (value) => typeof value === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(value),
-  plugin_version: (value) => typeof value === 'string' && /^\d+\.\d+$/.test(value) && value.length <= MAX_STRING_LENGTH,
-  host: (value) => HOSTS.includes(value),
+  plugin_version: (value) => typeof value === 'string' && /^\d+\.\d+(?:\.\d+)?$/.test(value) && value.length <= MAX_STRING_LENGTH,
 };
 
 const HOOK_FIELDS = {
+  host: (value) => HOSTS.includes(value),
   mode: (value) => MODES.includes(value),
   tool_calls_bucket: (value) => COUNT_BUCKETS.includes(value),
-  redactions_bucket: (value) => COUNT_BUCKETS.includes(value),
   capped_outputs_bucket: (value) => COUNT_BUCKETS.includes(value),
   bytes_saved_bucket: (value) => BYTE_BUCKETS.includes(value),
+  input_tokens_saved_bucket: (value) => BYTE_BUCKETS.includes(value),
 };
 
 const PROXY_FIELDS = {
+  provider: (value) => PROVIDERS.includes(value),
+  mode: (value) => MODES.includes(value),
   rewrites_applied_bucket: (value) => COUNT_BUCKETS.includes(value),
   rewrites_skipped_cache_bucket: (value) => COUNT_BUCKETS.includes(value),
   input_tokens_saved_bucket: (value) => BYTE_BUCKETS.includes(value),
-  prompt_cache_hit: (value) => YES_NO_UNKNOWN.includes(value),
+};
+
+const ACTIVE_DAY_FIELDS = { host: (value) => HOSTS.includes(value) };
+const HOOK_FAILURE_FIELDS = {
+  host: (value) => HOSTS.includes(value),
+  failure_stage: (value) => FAILURE_STAGES.includes(value),
+};
+const PROXY_FAILURE_FIELDS = {
+  provider: (value) => PROVIDERS.includes(value),
+  failure_stage: (value) => FAILURE_STAGES.includes(value),
 };
 
 function fieldsForEvent(eventType) {
-  return eventType === 'hook_summary' ? HOOK_FIELDS : PROXY_FIELDS;
+  if (eventType === 'hook_summary') return HOOK_FIELDS;
+  if (eventType === 'proxy_summary') return PROXY_FIELDS;
+  if (eventType === 'active_day') return ACTIVE_DAY_FIELDS;
+  if (eventType === 'hook_failure_summary') return HOOK_FAILURE_FIELDS;
+  return PROXY_FAILURE_FIELDS;
 }
 
 export function countBucket(count) {
@@ -92,6 +112,10 @@ export const TELEMETRY_DETAILS_URL = 'https://github.com/yuzushi-dev/Sando/blob/
 // session-handoff/docs/telemetry-canary-report.md.
 export const TELEMETRY_ENDPOINT = 'https://telemetry.yuzushi.party/v1/logs';
 
+export function isDoNotTrack(env = process.env) {
+  return env.DO_NOT_TRACK !== undefined && env.DO_NOT_TRACK !== '' && env.DO_NOT_TRACK !== '0';
+}
+
 function record(value) { return value !== null && typeof value === 'object' && !Array.isArray(value); }
 
 function emptyTelemetryConfig() {
@@ -140,11 +164,10 @@ export function statusTelemetry(configPath = defaultTelemetryConfigPath()) {
   return readTelemetryConfig(configPath);
 }
 
-/** Only an explicit `yes` in an interactive session enables collection; anything else
- *  (blank, `no`, EOF, or a non-interactive caller) writes the disabled prompt marker so
- *  upgrades and reinstalls never re-prompt or silently opt a user in. */
+/** Only an explicit `yes` in an interactive session enables collection. */
 export function enableTelemetry({ configPath = defaultTelemetryConfigPath(), answer, interactive = true, now = () => new Date() } = {}) {
-  if (!interactive || typeof answer !== 'string' || answer.trim().toLowerCase() !== 'yes') {
+  if (!interactive) return { ...readTelemetryConfig(configPath), exitCode: 1 };
+  if (typeof answer !== 'string' || answer.trim().toLowerCase() !== 'yes') {
     return writeTelemetryConfig(configPath, { schema_version: TELEMETRY_CONFIG_VERSION, enabled: false, prompted_consent_version: CONSENT_VERSION });
   }
   return writeTelemetryConfig(configPath, {
@@ -157,14 +180,21 @@ export function enableTelemetry({ configPath = defaultTelemetryConfigPath(), ans
   });
 }
 
-const QUEUE_MAX_ROWS = 256;
-const QUEUE_MAX_BYTES = 256 * 1024;
+// 30 days of daily aggregates plus activity markers for both supported hosts,
+// with headroom for concurrent event dimensions and temporary outages.
+const QUEUE_MAX_ROWS = 4096;
+const QUEUE_MAX_BYTES = 4 * 1024 * 1024;
+const ACTIVE_DAY_RETENTION_DAYS = 30;
 const DEFAULT_BATCH_MAX = 32;
+const LEASE_MS = 5 * 60 * 1000;
+const RETRY_DELAYS_MS = [60_000, 300_000, 1_800_000, 7_200_000, 21_600_000];
+const CHILD_ENV_KEYS = ['HTTPS_PROXY', 'HTTP_PROXY', 'NO_PROXY', 'NODE_EXTRA_CA_CERTS', 'SSL_CERT_FILE'];
 
-function emptyCounters() { return { schema_version: TELEMETRY_CONFIG_VERSION, counters: {} }; }
+function emptyCounters() { return { schema_version: TELEMETRY_CONFIG_VERSION, counters: {}, active_days: {} }; }
 function readCounters(countersPath) {
   if (!fs.existsSync(countersPath)) return emptyCounters();
-  return JSON.parse(fs.readFileSync(countersPath, 'utf8'));
+  const state = JSON.parse(fs.readFileSync(countersPath, 'utf8'));
+  return { ...state, counters: state.counters ?? {}, active_days: state.active_days ?? {} };
 }
 
 function readQueueRows(queuePath) {
@@ -181,24 +211,29 @@ function writeQueueRows(queuePath, rows) {
   fs.chmodSync(queuePath, 0o600);
 }
 
-/** Enforces the bounded queue (256 rows / 256 KiB), dropping the oldest rows first —
+/** Enforces the bounded queue (4096 rows / 4 MiB), dropping the oldest rows first —
  *  a telemetry backlog must never grow without bound or block product behavior. */
 function appendQueueRows(queuePath, newRows) {
+  ensureDirectory(path.dirname(queuePath));
   withLock(`${queuePath}.lock`, () => {
-    let rows = [...readQueueRows(queuePath), ...newRows];
+    let rows = readQueueRows(queuePath);
+    const keys = new Set(rows.map((row) => queueKey(row)));
+    for (const row of newRows) {
+      if (!keys.has(queueKey(row))) { rows.push(row); keys.add(queueKey(row)); }
+    }
     if (rows.length > QUEUE_MAX_ROWS) rows = rows.slice(rows.length - QUEUE_MAX_ROWS);
     while (rows.length > 0 && Buffer.byteLength(rows.map((row) => JSON.stringify(row)).join('\n')) > QUEUE_MAX_BYTES) rows.shift();
     writeQueueRows(queuePath, rows);
   });
 }
 
-function majorityCacheHit(entry) {
-  const yes = entry.cacheHitYes ?? 0;
-  const no = entry.cacheHitNo ?? 0;
-  const unknown = entry.cacheHitUnknown ?? 0;
-  if (yes > no && yes >= unknown) return 'yes';
-  if (no > yes && no >= unknown) return 'no';
-  return 'unknown';
+function queueKey(row) {
+  return [row.event, row.day_utc, row.plugin_version, row.host ?? row.provider ?? '', row.mode ?? '', row.failureStage ?? row.failure_stage ?? ''].join('|');
+}
+
+function publicRow(row) {
+  const allowed = { ...SHARED_FIELDS, ...fieldsForEvent(row.event) };
+  return Object.fromEntries(Object.entries(row).filter(([key]) => Object.hasOwn(allowed, key)));
 }
 
 function bucketEntry(entry, pluginVersion) {
@@ -207,35 +242,83 @@ function bucketEntry(entry, pluginVersion) {
       schema_version: TELEMETRY_CONFIG_VERSION, event: 'hook_summary', day_utc: entry.day, plugin_version: pluginVersion,
       host: entry.host, mode: entry.mode,
       tool_calls_bucket: countBucket(entry.toolCalls ?? 0),
-      redactions_bucket: countBucket(entry.redactions ?? 0),
       capped_outputs_bucket: countBucket(entry.cappedOutputs ?? 0),
       bytes_saved_bucket: byteBucket(entry.bytesSaved ?? 0),
+      input_tokens_saved_bucket: byteBucket(entry.inputTokensSaved ?? 0),
     };
   }
-  return {
+  if (entry.event === 'proxy_summary') return {
     schema_version: TELEMETRY_CONFIG_VERSION, event: 'proxy_summary', day_utc: entry.day, plugin_version: pluginVersion,
-    host: entry.host,
+    provider: entry.provider ?? 'unknown', mode: entry.mode ?? 'enforce',
     rewrites_applied_bucket: countBucket(entry.rewritesApplied ?? 0),
     rewrites_skipped_cache_bucket: countBucket(entry.rewritesSkippedCache ?? 0),
     input_tokens_saved_bucket: byteBucket(entry.inputTokensSaved ?? 0),
-    prompt_cache_hit: majorityCacheHit(entry),
+  };
+  if (entry.event === 'hook_failure_summary') return {
+    schema_version: TELEMETRY_CONFIG_VERSION, event: 'hook_failure_summary', day_utc: entry.day, plugin_version: pluginVersion,
+    host: entry.host, failure_stage: entry.failureStage,
+  };
+  return {
+    schema_version: TELEMETRY_CONFIG_VERSION, event: 'proxy_failure_summary', day_utc: entry.day, plugin_version: pluginVersion,
+    provider: entry.provider, failure_stage: entry.failureStage,
   };
 }
 
 /** Accumulates raw per-day counts in memory/on disk; values are only bucketed (and thus
  *  only ever leave the machine) once `closeDay` closes a finished UTC day. */
-export function incrementCounter({ statePaths, day, event, host, mode, deltas = {} }) {
-  if (!['hook_summary', 'proxy_summary'].includes(event)) throw new Error('incrementCounter: invalid event');
-  const key = `${day}|${event}|${host}|${mode ?? ''}`;
+export function incrementCounter({ statePaths, day, event, host, provider, mode, failureStage, deltas = {} }) {
+  if (!['hook_summary', 'proxy_summary', 'hook_failure_summary', 'proxy_failure_summary'].includes(event)) {
+    throw new Error('incrementCounter: invalid event');
+  }
+  const isProxy = event.startsWith('proxy_');
+  const dimension = isProxy ? provider : host;
+  const key = event.includes('failure')
+    ? [day, event, dimension, failureStage ?? ''].join('|')
+    : [day, event, dimension, mode ?? ''].join('|');
   ensureDirectory(path.dirname(statePaths.counters));
   withLock(`${statePaths.counters}.lock`, () => {
     const state = readCounters(statePaths.counters);
-    const existing = state.counters[key] ?? { day, event, host, mode: mode ?? null };
+    const existing = state.counters[key] ?? {
+      day, event, ...(isProxy ? { provider: dimension } : { host: dimension }),
+      ...(event.endsWith('_summary') && !event.includes('failure') ? { mode: mode ?? null } : {}),
+      ...(event.includes('failure') ? { failureStage } : {}),
+    };
     for (const [field, value] of Object.entries(deltas)) {
       if (!Number.isInteger(value) || value < 0) throw new Error(`incrementCounter: invalid delta ${field}`);
       existing[field] = (existing[field] ?? 0) + value;
     }
     state.counters[key] = existing;
+    atomicWrite(statePaths.counters, state);
+  });
+}
+
+export function recordFailure({ statePaths, day, event, host, provider, failureStage }) {
+  incrementCounter({
+    statePaths, day, event, host, provider, failureStage, deltas: { count: 1 },
+  });
+}
+
+/** Queues a single non-aggregate activity marker for this UTC day and host. */
+export function recordActiveDay({ statePaths, day, pluginVersion, host }) {
+  const marker = {
+    schema_version: SCHEMA_VERSION, event: 'active_day', day_utc: day, plugin_version: pluginVersion, host,
+  };
+  const validatedMarker = validateEvent(marker);
+  const activeDayKey = `${day}|${host}`;
+  ensureDirectory(path.dirname(statePaths.counters));
+  withLock(`${statePaths.counters}.lock`, () => {
+    const state = readCounters(statePaths.counters);
+    const activeDays = state.active_days;
+    const cutoff = Date.parse(`${day}T00:00:00Z`) - (ACTIVE_DAY_RETENTION_DAYS - 1) * 86_400_000;
+    for (const [key, recordedDay] of Object.entries(activeDays)) {
+      if (Date.parse(`${recordedDay}T00:00:00Z`) < cutoff) delete activeDays[key];
+    }
+    if (Object.hasOwn(activeDays, activeDayKey)) {
+      atomicWrite(statePaths.counters, state);
+      return;
+    }
+    appendQueueRows(statePaths.queue, [validatedMarker]);
+    activeDays[activeDayKey] = day;
     atomicWrite(statePaths.counters, state);
   });
 }
@@ -252,11 +335,11 @@ export function closeDay({ statePaths, day, pluginVersion }) {
       if (entry.day !== day) { remaining[key] = entry; continue; }
       closedRows.push(validateEvent(bucketEntry(entry, pluginVersion)));
     }
+    if (closedRows.length) appendQueueRows(statePaths.queue, closedRows);
     state.counters = remaining;
     ensureDirectory(path.dirname(statePaths.counters));
     atomicWrite(statePaths.counters, state);
   });
-  if (closedRows.length) appendQueueRows(statePaths.queue, closedRows);
   return closedRows;
 }
 
@@ -264,14 +347,16 @@ function launchDetachedFlush({ statePaths, configPath, spawnImpl }) {
   try {
     const entryPath = fileURLToPath(new URL('./telemetry-flush-entry.mjs', import.meta.url));
     const child = spawnImpl(process.execPath, [entryPath, '--queue', statePaths.queue, '--config', configPath], {
-      detached: true, env: {}, stdio: 'ignore', windowsHide: true,
+      detached: true,
+      env: Object.fromEntries(CHILD_ENV_KEYS.filter((key) => process.env[key] !== undefined).map((key) => [key, process.env[key]])),
+      stdio: 'ignore', windowsHide: true,
     });
     child.unref();
   } catch { /* telemetry must never affect the caller */ }
 }
 
-/** Closes every raw counter day before `day` and starts one detached uploader.
- * The child receives only local state paths and an empty environment. */
+/** Closes every raw counter day before `day` and starts one detached uploader
+ * whenever any queue row remains, including a queue from a previous session. */
 export function closeFinishedDays({
   statePaths, configPath = defaultTelemetryConfigPath(), day, pluginVersion,
   spawnImpl = spawn,
@@ -287,18 +372,44 @@ export function closeFinishedDays({
   for (const closedDay of [...days].sort()) {
     closedRows.push(...closeDay({ statePaths, day: closedDay, pluginVersion }));
   }
-  if (closedRows.length) launchDetachedFlush({ statePaths, configPath, spawnImpl });
+  if (fs.existsSync(statePaths.queue) && readQueueRows(statePaths.queue).length) {
+    launchDetachedFlush({ statePaths, configPath, spawnImpl });
+  }
   return closedRows;
 }
 
-export function loadBatch({ statePaths, max = DEFAULT_BATCH_MAX } = {}) {
-  return readQueueRows(statePaths.queue).slice(0, max);
-}
-
-export function ackBatch({ statePaths, count }) {
+function claimBatch({ statePaths, max, now = Date.now, leaseMs = LEASE_MS }) {
+  let claimed = [];
   withLock(`${statePaths.queue}.lock`, () => {
     const rows = readQueueRows(statePaths.queue);
-    writeQueueRows(statePaths.queue, rows.slice(count));
+    const timestamp = now();
+    const available = rows.filter((row) => !row._permanent && (!row._nextAttemptAt || row._nextAttemptAt <= timestamp));
+    if (!available.length) return;
+    if (available.some((row) => row._leaseUntil > timestamp)) return;
+    const leaseId = `${process.pid}-${timestamp}-${Math.random().toString(36).slice(2)}`;
+    const selected = available.slice(0, max);
+    const selectedKeys = new Set(selected.map(queueKey));
+    for (const row of rows) {
+      if (selectedKeys.has(queueKey(row))) { row._leaseId = leaseId; row._leaseUntil = timestamp + leaseMs; }
+    }
+    writeQueueRows(statePaths.queue, rows);
+    claimed = selected.map((row) => ({ ...row, _leaseId: leaseId, _leaseUntil: timestamp + leaseMs }));
+  });
+  return claimed;
+}
+
+export function loadBatch({ statePaths, max = DEFAULT_BATCH_MAX, lease = true, now = Date.now } = {}) {
+  if (lease) return claimBatch({ statePaths, max, now });
+  return readQueueRows(statePaths.queue).filter((row) => !row._permanent && (!row._nextAttemptAt || row._nextAttemptAt <= now())).slice(0, max).map(publicRow);
+}
+
+export function ackBatch({ statePaths, count, leaseId } = {}) {
+  withLock(`${statePaths.queue}.lock`, () => {
+    const rows = readQueueRows(statePaths.queue);
+    if (!leaseId) { writeQueueRows(statePaths.queue, rows.slice(count)); return; }
+    const leased = rows.filter((row) => row._leaseId === leaseId).slice(0, count);
+    const keys = new Set(leased.map(queueKey));
+    writeQueueRows(statePaths.queue, rows.filter((row) => !keys.has(queueKey(row))));
   });
 }
 
@@ -309,7 +420,7 @@ export function toOtlpLogs(rows) {
       scopeLogs: [{
         logRecords: rows.map((row) => ({
           body: { stringValue: 'sando.daily_aggregate' },
-          attributes: Object.entries(row).map(([key, value]) => ({ key, value: { stringValue: String(value) } })),
+          attributes: Object.entries(publicRow(row)).map(([key, value]) => ({ key, value: { stringValue: String(value) } })),
         })),
       }],
     }],
@@ -317,30 +428,78 @@ export function toOtlpLogs(rows) {
 }
 
 export function previewNextUpload({ statePaths, endpoint = TELEMETRY_ENDPOINT, max = DEFAULT_BATCH_MAX } = {}) {
-  const rows = loadBatch({ statePaths, max });
+  const rows = loadBatch({ statePaths, max, lease: false });
   return { url: endpoint, headers: { 'content-type': 'application/json' }, body: toOtlpLogs(rows) };
 }
 
-/** Uploads at most one batch. Every failure mode (timeout, network error, non-2xx) is
- *  swallowed and reported as `sent: 0` — telemetry must never throw into, or change the
- *  outcome of, the hook or proxy call that triggered a day close. */
-export async function flushQueue({ statePaths, endpoint = TELEMETRY_ENDPOINT, max = DEFAULT_BATCH_MAX, timeoutMs = 3000 } = {}) {
-  const rows = loadBatch({ statePaths, max });
-  if (rows.length === 0) return { sent: 0 };
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), timeoutMs);
-  try {
-    const response = await fetch(endpoint, {
-      method: 'POST', headers: { 'content-type': 'application/json' },
-      body: JSON.stringify(toOtlpLogs(rows)), signal: controller.signal,
-    });
-    if (!response.ok) return { sent: 0 };
-    ackBatch({ statePaths, count: rows.length });
-    return { sent: rows.length };
-  } catch {
-    return { sent: 0 };
-  } finally {
-    clearTimeout(timer);
+/** Drains eligible batches. Every failure mode is swallowed and reported without
+ * changing the outcome of the hook or proxy call that triggered the flush. */
+function retryAfterMs(response, now) {
+  const value = response.headers?.get?.('retry-after');
+  if (!value) return 0;
+  const seconds = Number(value);
+  if (Number.isFinite(seconds)) return Math.max(0, seconds * 1000);
+  const timestamp = Date.parse(value);
+  return Number.isNaN(timestamp) ? 0 : Math.max(0, timestamp - now);
+}
+
+function updateClaimedRows({ statePaths, leaseId, update }) {
+  withLock(`${statePaths.queue}.lock`, () => {
+    const rows = readQueueRows(statePaths.queue);
+    for (const row of rows) if (row._leaseId === leaseId) update(row);
+    writeQueueRows(statePaths.queue, rows);
+  });
+}
+
+function isRetryableStatus(status) { return [429, 502, 503, 504].includes(status); }
+
+export async function flushQueue({
+  statePaths, endpoint = TELEMETRY_ENDPOINT, max = DEFAULT_BATCH_MAX, timeoutMs = 3000,
+  fetchImpl = fetch, now = Date.now, random = Math.random, sleep = async () => {},
+} = {}) {
+  const result = { sent: 0, rejectedLogRecords: 0 };
+  while (true) {
+    const rows = claimBatch({ statePaths, max, now });
+    if (rows.length === 0) return result;
+    const leaseId = rows[0]._leaseId;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      const response = await fetchImpl(endpoint, {
+        method: 'POST', headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(toOtlpLogs(rows)), signal: controller.signal,
+      });
+      if (response.ok) {
+        let body = {};
+        try { body = await response.json(); } catch { /* empty 2xx body */ }
+        result.rejectedLogRecords += Number(body?.partialSuccess?.rejectedLogRecords || 0);
+        ackBatch({ statePaths, count: rows.length, leaseId });
+        result.sent += rows.length;
+      } else if (isRetryableStatus(response.status)) {
+        updateClaimedRows({ statePaths, leaseId, update: (row) => {
+          const attempt = (row._attemptCount ?? 0) + 1;
+          const base = RETRY_DELAYS_MS[Math.min(attempt - 1, RETRY_DELAYS_MS.length - 1)];
+          row._attemptCount = attempt;
+          row._nextAttemptAt = now() + Math.max(base * random(), retryAfterMs(response, now()));
+          delete row._leaseId; delete row._leaseUntil;
+        }});
+        return result;
+      } else {
+        ackBatch({ statePaths, count: rows.length, leaseId });
+      }
+    } catch {
+      updateClaimedRows({ statePaths, leaseId, update: (row) => {
+        const attempt = (row._attemptCount ?? 0) + 1;
+        const base = RETRY_DELAYS_MS[Math.min(attempt - 1, RETRY_DELAYS_MS.length - 1)];
+        row._attemptCount = attempt;
+        row._nextAttemptAt = now() + base * random();
+        delete row._leaseId; delete row._leaseUntil;
+      }});
+      return result;
+    } finally {
+      clearTimeout(timer);
+    }
+    await sleep(0);
   }
 }
 

--- a/plugins/sando/lib/version.mjs
+++ b/plugins/sando/lib/version.mjs
@@ -1,0 +1,29 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const VERSION_PATTERN = /^\d+\.\d+(?:\.\d+)?$/;
+const STANDALONE_VERSION = '0.2.0';
+const METADATA_FILES = ['package.json', '.claude-plugin/plugin.json', '.codex-plugin/plugin.json'];
+
+function findMetadataFile() {
+  let directory = path.resolve(import.meta.dirname, '..');
+  while (true) {
+    for (const relativePath of METADATA_FILES) {
+      const file = path.join(directory, relativePath);
+      if (fs.existsSync(file)) return file;
+    }
+    const parent = path.dirname(directory);
+    if (parent === directory) break;
+    directory = parent;
+  }
+  return null;
+}
+
+const metadataPath = findMetadataFile();
+const metadata = metadataPath ? JSON.parse(fs.readFileSync(metadataPath, 'utf8')) : { version: STANDALONE_VERSION };
+if (typeof metadata.version !== 'string' || !VERSION_PATTERN.test(metadata.version)) {
+  throw new Error(`Invalid Sando version in ${metadataPath}`);
+}
+
+// Evaluated once per process: no repeated filesystem reads in telemetry paths.
+export const PLUGIN_VERSION = metadata.version;

--- a/scripts/sync-bundles.mjs
+++ b/scripts/sync-bundles.mjs
@@ -10,7 +10,7 @@ const bundles = [
 ];
 
 for (const directory of bundles) {
-  for (const file of ['core.mjs', 'routing.mjs', 'active-session.mjs', 'statusline.mjs', 'redaction-profile.mjs', 'redaction-config.mjs', 'secret-redaction.mjs', 'provider-usage.mjs', 'telemetry.mjs', 'telemetry-cli.mjs', 'telemetry-flush-entry.mjs', 'session-start.mjs']) {
+  for (const file of ['core.mjs', 'routing.mjs', 'active-session.mjs', 'statusline.mjs', 'redaction-profile.mjs', 'redaction-config.mjs', 'secret-redaction.mjs', 'provider-usage.mjs', 'telemetry.mjs', 'telemetry-cli.mjs', 'telemetry-flush-entry.mjs', 'session-start.mjs', 'version.mjs']) {
     await fs.copyFile(path.join(source, file), path.join(root, directory, file));
   }
 }


### PR DESCRIPTION
## Perche'

Il consenso alla telemetria veniva chiesto solo dal `postinstall` npm, ma il wrapper del plugin **non ha un `package.json`**: dal marketplace sando si installa come copia di directory e nessuno script npm viene mai eseguito. Chi installa sando come plugin Claude o Codex non e' mai stato interrogato, e strutturalmente non poteva esserlo. In due giorni di endpoint attivo e' arrivata **una** riga da sando, dalla macchina del manutentore.

## Il bug di consenso

`sando telemetry enable` in sessione non interattiva stampava un errore ma **poi scriveva comunque `enabled:false`**, revocando in silenzio un consenso gia' dato. Puo' essere accaduto a utenti terzi che avevano acconsentito. Ora esce con codice 1 senza toccare il file, e un `enable` interattivo su telemetria gia' attiva non la disattiva piu' con una risposta vuota.

## Il provider sbagliato

Il proxy rilevava il provider con `detectProviderBody()` e **poi lo scartava**, registrando `host: 'claude'` fisso. Tutto il traffico proxy risultava Claude anche quando era OpenAI — proprio sulla dimensione che serve a decidere quali provider supportare. Non un dato mancante: un dato falso.

Ora gli eventi di proxy portano il `provider` reale (`anthropic | openai | unknown`); `host` resta per hook e `active_day`, dove significa davvero il client. **Le righe precedenti a questo commit non sono confrontabili con le successive.**

## Cosa cambia per gli utenti

Chi non e' mai stato interrogato riceve una notifica una tantum all'avvio sessione. E' una notifica e non un prompt di proposito: gli hook girano nel ciclo di vita del client con stdout riservato al protocollo, e un prompt bloccante romperebbe il tool. Resta **opt-in, default off**, piu' `DO_NOT_TRACK` come override di runtime.

`TELEMETRY.md` e' aggiornato: il marker `active_day` avvicina l'ingest all'uso reale, ed e' un cambiamento nel contratto con gli utenti.

## Errori, prima invisibili

Aggiunti `hook_failure_summary` e `proxy_failure_summary` con `failure_stage` come enum chiuso di 8 valori. Prima non esisteva alcun segnale su dove il plugin si rompe in mano agli utenti.

## Correttezza

- `closeDay()` cancellava i counter **prima** di accodarli: un crash tra le due scritture perdeva il giorno.
- Nessuna lease sui batch: due flush concorrenti potevano duplicare invii o rimuovere righe non spedite.
- `recordActiveDay()` deduplicava solo contro le righe ancora in coda, quindi riaccodava il marker dopo ogni flush.
- I processi figli partivano con **environment vuoto**, perdendo `HTTPS_PROXY` e `NODE_EXTRA_CA_CERTS`: dietro un proxy aziendale l'endpoint era irraggiungibile in silenzio.

## Riduzione del costo privacy

Rimossi dai dati in uscita `prompt_cache_hit`, il cui nome non corrispondeva all'implementazione e che duplicava `rewrites_skipped_cache_bucket`, e `redactions_bucket`, che non dimostra la correttezza della redazione e aggiunge una dimensione capace di separare ambienti con workflow insoliti. Restano disponibili in locale.

## plugin_version

Era divergente su quattro valori. Non essendoci identificatori di installazione — ed e' una scelta deliberata — e' l'**unico** segnale per sapere se una release e' stata adottata. Ora deriva da `package.json`, con un test che fallisce se le fonti divergono (verificato sabotando una versione).

## Verifica

`241 package + 142 benchmark + 49 bundle = 432 test, 0 fail`. I tre bundle sono byte-identici al sorgente. Schema verificato end-to-end con probe OTLP reali attraverso il collector.

## Non incluso di proposito

Nessun identificatore di installazione: la telemetria resta anonima, non pseudonima. Nessun passaggio a opt-out: le [linee guida EDPB 2/2023 sull'art. 5(3) ePrivacy](https://www.edpb.europa.eu/system/files/2024-10/edpb_guidelines_202302_technical_scope_art_53_eprivacydirective_v2_en_0.pdf) stabiliscono che l'opt-out non e' sufficiente per analytics non essenziali.

Conseguenza da tenere presente: utenti unici, retention e churn restano non misurabili.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
