### PR TITLE
Correggi il consenso: systemMessage ignorato, y trattato come rifiuto, risposta in chat

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -1,13 +1,19 @@
 # Sando telemetry
 
-Opt-in, off by default. Nothing is sent unless you run `telemetry-cli.mjs
-enable` (see "Controlling it" below for the exact path) and answer `yes`
-at the interactive prompt.
+Opt-in, off by default. Nothing is sent unless you explicitly answer the
+consent prompt with `y`, `yes`, `n`, or `no`, or use one of the controls below.
+Input is case-insensitive. An empty or unrecognized answer leaves telemetry off
+without recording a decline.
 
 If you installed via the Claude Code marketplace
 (`/plugin install sando@yuzushi`), a one-line reminder appears at the start
-of each session until you've made a decision. The reminder only informs you.
-It never blocks a session or prompts by itself.
+of the first session. It records that it was shown before displaying the
+reminder, so it is shown only once. The reminder only informs you. It never
+blocks a session or prompts by itself.
+
+The local consent state is explicit: `unasked`, `asked`, `enabled`, or
+`declined`. A decline is final for the first-use reminder. The state and any
+queued data stay on the local machine.
 
 If `DO_NOT_TRACK` is set to any non-empty value other than `0`, it is a
 runtime privacy override: Sando does not prompt, collect, queue, or upload
@@ -46,41 +52,49 @@ identifying field. Values are always bucketed, never a raw count or byte value.
 
 ## Where it goes
 
-The endpoint is `https://telemetry.yuzushi.party/v1/logs`. It uses a shared
-backend (OpenTelemetry Collector → Loki → Grafana) also used by the
-`session-handoff` project. Each project has its own closed schema. See
-`~/selfhosted/telemetry/docs/telemetry-privacy.md` (separate infra repo,
-shared with session-handoff) for the full data inventory,
-retention, and processor list, and
-`~/selfhosted/telemetry/docs/telemetry-canary-report.md` for the current
-release status. As of writing, the canary and independent privacy review
-remain open. The endpoint is live before those gates close. That is an
-explicit choice, not evidence that the gates are complete.
+The endpoint is `https://telemetry.yuzushi.party/v1/logs`. Data is sent over
+HTTPS to a shared backend: an OpenTelemetry Collector receives the validated
+JSON rows, Loki stores them, and Grafana is used for inspection. Sando rows
+use a closed schema separate from other projects. The collector receives only
+the application payload described here: Sando does not put transcript text,
+tool output, or identifiers into telemetry rows.
 
-Retention: 13 months, aggregate rows only.
+Server retention is 13 months for aggregate rows only. The local upload queue
+is bounded to approximately 30 days of daily rows (up to 4096 rows / 4 MiB);
+older unsent rows are evicted first during an outage.
 
-The local upload queue is bounded to approximately 30 days of daily rows (up to
-4096 rows / 4 MiB); older unsent rows are evicted first during an outage.
+The endpoint is live. This page does not claim that the canary rollout or an
+independent privacy review is complete; the independent review remains open.
 
 ## Controlling it
 
-There's no global `sando` command yet. Run `telemetry-cli.mjs` directly.
+When the SessionStart reminder is visible, reply with one exact full message:
+
+```text
+sando telemetry yes
+sando telemetry no
+```
+
+These commands are matched literally; natural-language variants and partial
+matches are ignored. `yes` enables collection and `no` declines or revokes it.
+
+There's no global shell `sando` command yet. Run `telemetry-cli.mjs` directly.
 The commands are the same either way, only the path to the script changes:
 
 **From a git checkout, or the `sandoichi` npm package:**
 
 ```sh
 node packages/sando/src/telemetry-cli.mjs status
-node packages/sando/src/telemetry-cli.mjs enable    # interactive only, asks yes/no
+node packages/sando/src/telemetry-cli.mjs enable    # interactive only, asks y/yes/n/no
 node packages/sando/src/telemetry-cli.mjs preview   # shows the exact next upload body, sends nothing
 node packages/sando/src/telemetry-cli.mjs flush
 node packages/sando/src/telemetry-cli.mjs disable --purge
 ```
 
 To disable telemetry persistently, run `disable` (optionally with `--purge` to
-remove queued local data). To disable it for a process or environment without
-changing the saved consent, set `DO_NOT_TRACK=1` (or any non-empty value other
-than `0`).
+remove queued local data), or reply `sando telemetry no` when the hook is
+installed. To disable it for a process or environment without changing the
+saved consent, set `DO_NOT_TRACK=1` (or any non-empty value other than `0`).
 
 **Installed via the Claude Code marketplace (`sando@yuzushi`):** the same
 script lives at `lib/telemetry-cli.mjs` inside the installed plugin

--- a/adapters/claude/sando/hooks/hooks.json
+++ b/adapters/claude/sando/hooks/hooks.json
@@ -12,6 +12,17 @@
         ]
       }
     ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/user-prompt-submit.mjs\"",
+            "timeout": 1
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": ".*",

--- a/adapters/claude/sando/hooks/user-prompt-submit.mjs
+++ b/adapters/claude/sando/hooks/user-prompt-submit.mjs
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+import { runUserPromptSubmit } from '../lib/user-prompt-submit.mjs';
+
+runUserPromptSubmit();

--- a/adapters/claude/sando/lib/session-start.mjs
+++ b/adapters/claude/sando/lib/session-start.mjs
@@ -1,7 +1,8 @@
 import path from 'node:path';
 
 import {
-  closeFinishedDays, defaultTelemetryConfigPath, defaultTelemetryStatePaths, isDoNotTrack, readTelemetryConfig, TELEMETRY_DETAILS_URL,
+  closeFinishedDays, defaultTelemetryConfigPath, defaultTelemetryStatePaths, isDoNotTrack, markTelemetryAsked,
+  readTelemetryConfig, TELEMETRY_DETAILS_URL,
 } from './telemetry.mjs';
 import { PLUGIN_VERSION } from './version.mjs';
 
@@ -10,28 +11,35 @@ export function runSessionStart({
   stdout = process.stdout,
   rootEnv = 'PLUGIN_ROOT',
   spawnImpl,
-  configPath = defaultTelemetryConfigPath(env),
-  statePaths = defaultTelemetryStatePaths(env),
+  configPath,
+  statePaths,
 } = {}) {
   try {
-    const config = readTelemetryConfig(configPath);
-    if (config.enabled && !isDoNotTrack(env)) {
+    if (isDoNotTrack(env)) {
+      stdout.write('{}\n');
+      return;
+    }
+    const telemetryConfigPath = configPath ?? defaultTelemetryConfigPath(env);
+    const telemetryStatePaths = statePaths ?? defaultTelemetryStatePaths(env);
+    const config = readTelemetryConfig(telemetryConfigPath);
+    if (config.enabled) {
       closeFinishedDays({
-        statePaths, configPath, day: new Date().toISOString().slice(0, 10),
+        statePaths: telemetryStatePaths, configPath: telemetryConfigPath, day: new Date().toISOString().slice(0, 10),
         pluginVersion: PLUGIN_VERSION, ...(spawnImpl ? { spawnImpl } : {}),
       });
     }
-    if (isDoNotTrack(env) || config.prompted_consent_version > 0) {
+    if (config.consent_state !== 'unasked' || !markTelemetryAsked(telemetryConfigPath)) {
       stdout.write('{}\n');
       return;
     }
     const pluginRoot = env[rootEnv] || path.resolve(import.meta.dirname, '..');
     const cli = path.join(pluginRoot, 'lib', 'telemetry-cli.mjs');
     stdout.write(`${JSON.stringify({
+      systemMessage: 'Sando can send anonymous aggregate telemetry (opt-in, off by default). '
+        + 'Reply with exactly `sando telemetry yes` or `sando telemetry no`, '
+        + `or run \`node "${cli}" enable\`. Details: ${TELEMETRY_DETAILS_URL}`,
       hookSpecificOutput: {
         hookEventName: 'SessionStart',
-        systemMessage: 'Sando can send anonymous aggregate telemetry (opt-in, off by default). '
-          + `Run \`node "${cli}" enable\` to turn it on. Details: ${TELEMETRY_DETAILS_URL}`,
       },
     })}\n`);
   } catch {

--- a/adapters/claude/sando/lib/telemetry-cli.mjs
+++ b/adapters/claude/sando/lib/telemetry-cli.mjs
@@ -10,7 +10,7 @@ import {
 } from './telemetry.mjs';
 
 const USAGE = 'Usage: sando telemetry <status|enable|disable [--purge]|preview|flush>\n';
-const CONSENT_PROMPT = `Enable anonymous telemetry? Full details at: ${TELEMETRY_DETAILS_URL} [y/N] `;
+const CONSENT_PROMPT = `Enable anonymous telemetry? Full details at: ${TELEMETRY_DETAILS_URL} [y/yes/N/no] `;
 
 async function defaultPrompt(message) {
   const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
@@ -47,10 +47,13 @@ export async function runTelemetryCli({
         stdout.write('telemetry already enabled.\n');
         return current;
       }
+      if (current.consent_state === 'declined') {
+        stdout.write('telemetry not enabled.\n');
+        return current;
+      }
       const answer = await prompt(CONSENT_PROMPT);
       const result = enableTelemetry({
-        configPath, interactive: true,
-        answer: /^(y|yes)$/i.test((answer ?? '').trim()) ? 'yes' : answer,
+        configPath, interactive: true, answer,
       });
       stdout.write(result.enabled ? 'telemetry enabled.\n' : 'telemetry not enabled.\n');
       return result;

--- a/adapters/claude/sando/lib/telemetry.mjs
+++ b/adapters/claude/sando/lib/telemetry.mjs
@@ -105,6 +105,7 @@ export function serializeEvent(payload) {
 export const TELEMETRY_CONFIG_VERSION = 1;
 export const CONSENT_VERSION = 1;
 export const TELEMETRY_DETAILS_URL = 'https://github.com/yuzushi-dev/Sando/blob/main/TELEMETRY.md';
+export const CONSENT_STATES = ['unasked', 'asked', 'enabled', 'declined'];
 // Canary phase: shared backend, fronted by a Cloudflare Tunnel so it's
 // reachable from any of the owner's machines (see
 // session-handoff/deploy/telemetry/). Rate-limited at nginx (30 req/min/IP).
@@ -119,12 +120,15 @@ export function isDoNotTrack(env = process.env) {
 function record(value) { return value !== null && typeof value === 'object' && !Array.isArray(value); }
 
 function emptyTelemetryConfig() {
-  return { schema_version: TELEMETRY_CONFIG_VERSION, enabled: false, prompted_consent_version: 0 };
+  return {
+    schema_version: TELEMETRY_CONFIG_VERSION, enabled: false, prompted_consent_version: 0, consent_state: 'unasked',
+  };
 }
 
 function validateTelemetryConfig(value) {
   if (!record(value) || value.schema_version !== TELEMETRY_CONFIG_VERSION || typeof value.enabled !== 'boolean'
-    || !Number.isInteger(value.prompted_consent_version) || value.prompted_consent_version < 0) {
+    || !Number.isInteger(value.prompted_consent_version) || value.prompted_consent_version < 0
+    || !CONSENT_STATES.includes(value.consent_state)) {
     throw new Error('telemetry config is invalid');
   }
   if (value.enabled) {
@@ -150,7 +154,14 @@ export function defaultTelemetryStatePaths(env = process.env) {
 
 export function readTelemetryConfig(configPath = defaultTelemetryConfigPath()) {
   if (!fs.existsSync(configPath)) return emptyTelemetryConfig();
-  return validateTelemetryConfig(JSON.parse(fs.readFileSync(configPath, 'utf8')));
+  const value = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+  // Legacy files cannot distinguish an explicit no from blank input or the old
+  // y-as-no bug. Keep that ambiguous decision as asked, not as a decline.
+  const migrated = Object.hasOwn(value, 'consent_state') ? value : {
+    ...value,
+    consent_state: value.enabled ? 'enabled' : value.prompted_consent_version > 0 ? 'asked' : 'unasked',
+  };
+  return validateTelemetryConfig(migrated);
 }
 
 function writeTelemetryConfig(configPath, config) {
@@ -164,19 +175,48 @@ export function statusTelemetry(configPath = defaultTelemetryConfigPath()) {
   return readTelemetryConfig(configPath);
 }
 
-/** Only an explicit `yes` in an interactive session enables collection. */
+export function normalizeConsentAnswer(answer) {
+  if (typeof answer !== 'string') return undefined;
+  const normalized = answer.trim().toLowerCase();
+  if (normalized === 'y' || normalized === 'yes') return 'yes';
+  if (normalized === 'n' || normalized === 'no') return 'no';
+  return undefined;
+}
+
+export function markTelemetryAsked(configPath = defaultTelemetryConfigPath()) {
+  ensureDirectory(path.dirname(configPath));
+  return withLock(`${configPath}.lock`, () => {
+    const current = readTelemetryConfig(configPath);
+    if (current.consent_state !== 'unasked') return false;
+    const next = {
+      ...current, enabled: false, prompted_consent_version: CONSENT_VERSION, consent_state: 'asked',
+    };
+    validateTelemetryConfig(next);
+    atomicWrite(configPath, next);
+    return true;
+  });
+}
+
+/** Only an explicit yes enables collection; explicit no declines, other input stays asked/off. */
 export function enableTelemetry({ configPath = defaultTelemetryConfigPath(), answer, interactive = true, now = () => new Date() } = {}) {
   if (!interactive) return { ...readTelemetryConfig(configPath), exitCode: 1 };
-  if (typeof answer !== 'string' || answer.trim().toLowerCase() !== 'yes') {
-    return writeTelemetryConfig(configPath, { schema_version: TELEMETRY_CONFIG_VERSION, enabled: false, prompted_consent_version: CONSENT_VERSION });
+  const normalized = normalizeConsentAnswer(answer);
+  if (normalized === 'yes') {
+    return writeTelemetryConfig(configPath, {
+      schema_version: TELEMETRY_CONFIG_VERSION,
+      enabled: true,
+      prompted_consent_version: CONSENT_VERSION,
+      consent_state: 'enabled',
+      consent_version: CONSENT_VERSION,
+      consented_at: now().toISOString(),
+      endpoint: TELEMETRY_ENDPOINT,
+    });
   }
   return writeTelemetryConfig(configPath, {
     schema_version: TELEMETRY_CONFIG_VERSION,
-    enabled: true,
+    enabled: false,
     prompted_consent_version: CONSENT_VERSION,
-    consent_version: CONSENT_VERSION,
-    consented_at: now().toISOString(),
-    endpoint: TELEMETRY_ENDPOINT,
+    consent_state: normalized === 'no' ? 'declined' : 'asked',
   });
 }
 
@@ -509,6 +549,7 @@ export function disableTelemetry({ configPath = defaultTelemetryConfigPath(), pu
     schema_version: TELEMETRY_CONFIG_VERSION,
     enabled: false,
     prompted_consent_version: previous.prompted_consent_version || CONSENT_VERSION,
+    consent_state: 'declined',
   });
   if (purge) {
     for (const target of [statePaths.counters, statePaths.queue]) fs.rmSync(target, { force: true });

--- a/adapters/claude/sando/lib/user-prompt-submit.mjs
+++ b/adapters/claude/sando/lib/user-prompt-submit.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import {
+  defaultTelemetryConfigPath, enableTelemetry, isDoNotTrack, readTelemetryConfig,
+} from './telemetry.mjs';
+
+const CONSENT_COMMANDS = new Map([
+  ['sando telemetry yes', 'yes'],
+  ['sando telemetry no', 'no'],
+]);
+
+function pass(stdout) { stdout.write('{}\n'); }
+
+export function runUserPromptSubmit({
+  env = process.env, input, stdout = process.stdout, configPath,
+} = {}) {
+  try {
+    if (isDoNotTrack(env)) {
+      pass(stdout);
+      return;
+    }
+    const telemetryConfigPath = configPath ?? defaultTelemetryConfigPath(env);
+    const rawInput = input === undefined ? fs.readFileSync(0, 'utf8') : input;
+    const prompt = JSON.parse(rawInput || '{}').prompt;
+    // Normalizza solo gli spazi ai bordi: non introduce ambiguita' (la stringa
+    // resta esatta) ed evita di perdere risposte genuine incollate con spazi.
+    const answer = typeof prompt === 'string' ? CONSENT_COMMANDS.get(prompt.trim()) : undefined;
+    if (!answer) {
+      pass(stdout);
+      return;
+    }
+    const current = readTelemetryConfig(telemetryConfigPath);
+    if (current.consent_state === 'declined' && answer === 'yes') {
+      pass(stdout);
+      return;
+    }
+    const result = enableTelemetry({ configPath: telemetryConfigPath, interactive: true, answer });
+    stdout.write(`${JSON.stringify({
+      systemMessage: result.enabled ? 'Sando telemetry enabled.' : 'Sando telemetry disabled.',
+    })}\n`);
+  } catch {
+    pass(stdout);
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
+  runUserPromptSubmit();
+}

--- a/adapters/claude/sando/tests/session-start-hook.test.mjs
+++ b/adapters/claude/sando/tests/session-start-hook.test.mjs
@@ -19,8 +19,11 @@ test('never prompted: shows a one-line, non-blocking telemetry notice', (t) => {
   t.after(() => fs.rmSync(directory, { recursive: true, force: true }));
   const output = run({ XDG_CONFIG_HOME: path.join(directory, '.config') });
   assert.equal(output.hookSpecificOutput.hookEventName, 'SessionStart');
-  assert.match(output.hookSpecificOutput.systemMessage, /telemetry-cli\.mjs" enable/);
-  assert.match(output.hookSpecificOutput.systemMessage, /TELEMETRY\.md/);
+  assert.equal(typeof output.systemMessage, 'string');
+  assert.equal(Object.hasOwn(output.hookSpecificOutput, 'systemMessage'), false);
+  assert.match(output.systemMessage, /sando telemetry yes/);
+  assert.match(output.systemMessage, /sando telemetry no/);
+  assert.match(output.systemMessage, /TELEMETRY\.md/);
 });
 
 test('already answered (enabled): stays silent', (t) => {
@@ -29,7 +32,7 @@ test('already answered (enabled): stays silent', (t) => {
   const configDir = path.join(directory, '.config', 'sando');
   fs.mkdirSync(configDir, { recursive: true });
   fs.writeFileSync(path.join(configDir, 'telemetry.json'), JSON.stringify({
-    schema_version: 1, enabled: true, prompted_consent_version: 1,
+    schema_version: 1, enabled: true, consent_state: 'enabled', prompted_consent_version: 1,
     consent_version: 1, consented_at: new Date().toISOString(), endpoint: 'https://example/v1/logs',
   }));
   const output = run({ XDG_CONFIG_HOME: path.join(directory, '.config') });
@@ -42,7 +45,7 @@ test('already answered (declined): stays silent', (t) => {
   const configDir = path.join(directory, '.config', 'sando');
   fs.mkdirSync(configDir, { recursive: true });
   fs.writeFileSync(path.join(configDir, 'telemetry.json'), JSON.stringify({
-    schema_version: 1, enabled: false, prompted_consent_version: 1,
+    schema_version: 1, enabled: false, consent_state: 'declined', prompted_consent_version: 1,
   }));
   const output = run({ XDG_CONFIG_HOME: path.join(directory, '.config') });
   assert.deepEqual(output, {});

--- a/adapters/codex/sando/lib/session-start.mjs
+++ b/adapters/codex/sando/lib/session-start.mjs
@@ -1,7 +1,8 @@
 import path from 'node:path';
 
 import {
-  closeFinishedDays, defaultTelemetryConfigPath, defaultTelemetryStatePaths, isDoNotTrack, readTelemetryConfig, TELEMETRY_DETAILS_URL,
+  closeFinishedDays, defaultTelemetryConfigPath, defaultTelemetryStatePaths, isDoNotTrack, markTelemetryAsked,
+  readTelemetryConfig, TELEMETRY_DETAILS_URL,
 } from './telemetry.mjs';
 import { PLUGIN_VERSION } from './version.mjs';
 
@@ -10,28 +11,35 @@ export function runSessionStart({
   stdout = process.stdout,
   rootEnv = 'PLUGIN_ROOT',
   spawnImpl,
-  configPath = defaultTelemetryConfigPath(env),
-  statePaths = defaultTelemetryStatePaths(env),
+  configPath,
+  statePaths,
 } = {}) {
   try {
-    const config = readTelemetryConfig(configPath);
-    if (config.enabled && !isDoNotTrack(env)) {
+    if (isDoNotTrack(env)) {
+      stdout.write('{}\n');
+      return;
+    }
+    const telemetryConfigPath = configPath ?? defaultTelemetryConfigPath(env);
+    const telemetryStatePaths = statePaths ?? defaultTelemetryStatePaths(env);
+    const config = readTelemetryConfig(telemetryConfigPath);
+    if (config.enabled) {
       closeFinishedDays({
-        statePaths, configPath, day: new Date().toISOString().slice(0, 10),
+        statePaths: telemetryStatePaths, configPath: telemetryConfigPath, day: new Date().toISOString().slice(0, 10),
         pluginVersion: PLUGIN_VERSION, ...(spawnImpl ? { spawnImpl } : {}),
       });
     }
-    if (isDoNotTrack(env) || config.prompted_consent_version > 0) {
+    if (config.consent_state !== 'unasked' || !markTelemetryAsked(telemetryConfigPath)) {
       stdout.write('{}\n');
       return;
     }
     const pluginRoot = env[rootEnv] || path.resolve(import.meta.dirname, '..');
     const cli = path.join(pluginRoot, 'lib', 'telemetry-cli.mjs');
     stdout.write(`${JSON.stringify({
+      systemMessage: 'Sando can send anonymous aggregate telemetry (opt-in, off by default). '
+        + 'Reply with exactly `sando telemetry yes` or `sando telemetry no`, '
+        + `or run \`node "${cli}" enable\`. Details: ${TELEMETRY_DETAILS_URL}`,
       hookSpecificOutput: {
         hookEventName: 'SessionStart',
-        systemMessage: 'Sando can send anonymous aggregate telemetry (opt-in, off by default). '
-          + `Run \`node "${cli}" enable\` to turn it on. Details: ${TELEMETRY_DETAILS_URL}`,
       },
     })}\n`);
   } catch {

--- a/adapters/codex/sando/lib/telemetry-cli.mjs
+++ b/adapters/codex/sando/lib/telemetry-cli.mjs
@@ -10,7 +10,7 @@ import {
 } from './telemetry.mjs';
 
 const USAGE = 'Usage: sando telemetry <status|enable|disable [--purge]|preview|flush>\n';
-const CONSENT_PROMPT = `Enable anonymous telemetry? Full details at: ${TELEMETRY_DETAILS_URL} [y/N] `;
+const CONSENT_PROMPT = `Enable anonymous telemetry? Full details at: ${TELEMETRY_DETAILS_URL} [y/yes/N/no] `;
 
 async function defaultPrompt(message) {
   const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
@@ -47,10 +47,13 @@ export async function runTelemetryCli({
         stdout.write('telemetry already enabled.\n');
         return current;
       }
+      if (current.consent_state === 'declined') {
+        stdout.write('telemetry not enabled.\n');
+        return current;
+      }
       const answer = await prompt(CONSENT_PROMPT);
       const result = enableTelemetry({
-        configPath, interactive: true,
-        answer: /^(y|yes)$/i.test((answer ?? '').trim()) ? 'yes' : answer,
+        configPath, interactive: true, answer,
       });
       stdout.write(result.enabled ? 'telemetry enabled.\n' : 'telemetry not enabled.\n');
       return result;

--- a/adapters/codex/sando/lib/telemetry.mjs
+++ b/adapters/codex/sando/lib/telemetry.mjs
@@ -105,6 +105,7 @@ export function serializeEvent(payload) {
 export const TELEMETRY_CONFIG_VERSION = 1;
 export const CONSENT_VERSION = 1;
 export const TELEMETRY_DETAILS_URL = 'https://github.com/yuzushi-dev/Sando/blob/main/TELEMETRY.md';
+export const CONSENT_STATES = ['unasked', 'asked', 'enabled', 'declined'];
 // Canary phase: shared backend, fronted by a Cloudflare Tunnel so it's
 // reachable from any of the owner's machines (see
 // session-handoff/deploy/telemetry/). Rate-limited at nginx (30 req/min/IP).
@@ -119,12 +120,15 @@ export function isDoNotTrack(env = process.env) {
 function record(value) { return value !== null && typeof value === 'object' && !Array.isArray(value); }
 
 function emptyTelemetryConfig() {
-  return { schema_version: TELEMETRY_CONFIG_VERSION, enabled: false, prompted_consent_version: 0 };
+  return {
+    schema_version: TELEMETRY_CONFIG_VERSION, enabled: false, prompted_consent_version: 0, consent_state: 'unasked',
+  };
 }
 
 function validateTelemetryConfig(value) {
   if (!record(value) || value.schema_version !== TELEMETRY_CONFIG_VERSION || typeof value.enabled !== 'boolean'
-    || !Number.isInteger(value.prompted_consent_version) || value.prompted_consent_version < 0) {
+    || !Number.isInteger(value.prompted_consent_version) || value.prompted_consent_version < 0
+    || !CONSENT_STATES.includes(value.consent_state)) {
     throw new Error('telemetry config is invalid');
   }
   if (value.enabled) {
@@ -150,7 +154,14 @@ export function defaultTelemetryStatePaths(env = process.env) {
 
 export function readTelemetryConfig(configPath = defaultTelemetryConfigPath()) {
   if (!fs.existsSync(configPath)) return emptyTelemetryConfig();
-  return validateTelemetryConfig(JSON.parse(fs.readFileSync(configPath, 'utf8')));
+  const value = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+  // Legacy files cannot distinguish an explicit no from blank input or the old
+  // y-as-no bug. Keep that ambiguous decision as asked, not as a decline.
+  const migrated = Object.hasOwn(value, 'consent_state') ? value : {
+    ...value,
+    consent_state: value.enabled ? 'enabled' : value.prompted_consent_version > 0 ? 'asked' : 'unasked',
+  };
+  return validateTelemetryConfig(migrated);
 }
 
 function writeTelemetryConfig(configPath, config) {
@@ -164,19 +175,48 @@ export function statusTelemetry(configPath = defaultTelemetryConfigPath()) {
   return readTelemetryConfig(configPath);
 }
 
-/** Only an explicit `yes` in an interactive session enables collection. */
+export function normalizeConsentAnswer(answer) {
+  if (typeof answer !== 'string') return undefined;
+  const normalized = answer.trim().toLowerCase();
+  if (normalized === 'y' || normalized === 'yes') return 'yes';
+  if (normalized === 'n' || normalized === 'no') return 'no';
+  return undefined;
+}
+
+export function markTelemetryAsked(configPath = defaultTelemetryConfigPath()) {
+  ensureDirectory(path.dirname(configPath));
+  return withLock(`${configPath}.lock`, () => {
+    const current = readTelemetryConfig(configPath);
+    if (current.consent_state !== 'unasked') return false;
+    const next = {
+      ...current, enabled: false, prompted_consent_version: CONSENT_VERSION, consent_state: 'asked',
+    };
+    validateTelemetryConfig(next);
+    atomicWrite(configPath, next);
+    return true;
+  });
+}
+
+/** Only an explicit yes enables collection; explicit no declines, other input stays asked/off. */
 export function enableTelemetry({ configPath = defaultTelemetryConfigPath(), answer, interactive = true, now = () => new Date() } = {}) {
   if (!interactive) return { ...readTelemetryConfig(configPath), exitCode: 1 };
-  if (typeof answer !== 'string' || answer.trim().toLowerCase() !== 'yes') {
-    return writeTelemetryConfig(configPath, { schema_version: TELEMETRY_CONFIG_VERSION, enabled: false, prompted_consent_version: CONSENT_VERSION });
+  const normalized = normalizeConsentAnswer(answer);
+  if (normalized === 'yes') {
+    return writeTelemetryConfig(configPath, {
+      schema_version: TELEMETRY_CONFIG_VERSION,
+      enabled: true,
+      prompted_consent_version: CONSENT_VERSION,
+      consent_state: 'enabled',
+      consent_version: CONSENT_VERSION,
+      consented_at: now().toISOString(),
+      endpoint: TELEMETRY_ENDPOINT,
+    });
   }
   return writeTelemetryConfig(configPath, {
     schema_version: TELEMETRY_CONFIG_VERSION,
-    enabled: true,
+    enabled: false,
     prompted_consent_version: CONSENT_VERSION,
-    consent_version: CONSENT_VERSION,
-    consented_at: now().toISOString(),
-    endpoint: TELEMETRY_ENDPOINT,
+    consent_state: normalized === 'no' ? 'declined' : 'asked',
   });
 }
 
@@ -509,6 +549,7 @@ export function disableTelemetry({ configPath = defaultTelemetryConfigPath(), pu
     schema_version: TELEMETRY_CONFIG_VERSION,
     enabled: false,
     prompted_consent_version: previous.prompted_consent_version || CONSENT_VERSION,
+    consent_state: 'declined',
   });
   if (purge) {
     for (const target of [statePaths.counters, statePaths.queue]) fs.rmSync(target, { force: true });

--- a/adapters/codex/sando/lib/user-prompt-submit.mjs
+++ b/adapters/codex/sando/lib/user-prompt-submit.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import {
+  defaultTelemetryConfigPath, enableTelemetry, isDoNotTrack, readTelemetryConfig,
+} from './telemetry.mjs';
+
+const CONSENT_COMMANDS = new Map([
+  ['sando telemetry yes', 'yes'],
+  ['sando telemetry no', 'no'],
+]);
+
+function pass(stdout) { stdout.write('{}\n'); }
+
+export function runUserPromptSubmit({
+  env = process.env, input, stdout = process.stdout, configPath,
+} = {}) {
+  try {
+    if (isDoNotTrack(env)) {
+      pass(stdout);
+      return;
+    }
+    const telemetryConfigPath = configPath ?? defaultTelemetryConfigPath(env);
+    const rawInput = input === undefined ? fs.readFileSync(0, 'utf8') : input;
+    const prompt = JSON.parse(rawInput || '{}').prompt;
+    // Normalizza solo gli spazi ai bordi: non introduce ambiguita' (la stringa
+    // resta esatta) ed evita di perdere risposte genuine incollate con spazi.
+    const answer = typeof prompt === 'string' ? CONSENT_COMMANDS.get(prompt.trim()) : undefined;
+    if (!answer) {
+      pass(stdout);
+      return;
+    }
+    const current = readTelemetryConfig(telemetryConfigPath);
+    if (current.consent_state === 'declined' && answer === 'yes') {
+      pass(stdout);
+      return;
+    }
+    const result = enableTelemetry({ configPath: telemetryConfigPath, interactive: true, answer });
+    stdout.write(`${JSON.stringify({
+      systemMessage: result.enabled ? 'Sando telemetry enabled.' : 'Sando telemetry disabled.',
+    })}\n`);
+  } catch {
+    pass(stdout);
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
+  runUserPromptSubmit();
+}

--- a/adapters/codex/sando/tests/session-start-hook.test.mjs
+++ b/adapters/codex/sando/tests/session-start-hook.test.mjs
@@ -28,8 +28,11 @@ for (const bundle of bundles) {
       XDG_CONFIG_HOME: path.join(directory, '.config'),
     });
     assert.equal(output.hookSpecificOutput.hookEventName, 'SessionStart');
-    assert.match(output.hookSpecificOutput.systemMessage, /telemetry-cli\.mjs.*enable/);
-    assert.match(output.hookSpecificOutput.systemMessage, /anonymous aggregate telemetry/);
+    assert.equal(typeof output.systemMessage, 'string');
+    assert.equal(Object.hasOwn(output.hookSpecificOutput, 'systemMessage'), false);
+    assert.match(output.systemMessage, /sando telemetry yes/);
+    assert.match(output.systemMessage, /sando telemetry no/);
+    assert.match(output.systemMessage, /anonymous aggregate telemetry/);
   });
 
   test(`${path.basename(path.dirname(bundle))} Codex SessionStart stays silent after a decision`, (t) => {
@@ -38,7 +41,7 @@ for (const bundle of bundles) {
     const configDir = path.join(directory, '.config', 'sando');
     fs.mkdirSync(configDir, { recursive: true });
     fs.writeFileSync(path.join(configDir, 'telemetry.json'), JSON.stringify({
-      schema_version: 1, enabled: false, prompted_consent_version: 1,
+      schema_version: 1, enabled: false, consent_state: 'declined', prompted_consent_version: 1,
     }));
     const output = run(path.join(bundle, 'hooks/session-start.mjs'), {
       XDG_CONFIG_HOME: path.join(directory, '.config'),

--- a/packages/sando/src/postinstall.mjs
+++ b/packages/sando/src/postinstall.mjs
@@ -8,10 +8,10 @@ import readline from 'node:readline/promises';
 import { pathToFileURL } from 'node:url';
 
 import {
-  CONSENT_VERSION, defaultTelemetryConfigPath, enableTelemetry, isDoNotTrack, readTelemetryConfig, TELEMETRY_DETAILS_URL,
+  defaultTelemetryConfigPath, enableTelemetry, isDoNotTrack, readTelemetryConfig, TELEMETRY_DETAILS_URL,
 } from './telemetry.mjs';
 
-const CONSENT_PROMPT = `Enable anonymous telemetry? Full details at: ${TELEMETRY_DETAILS_URL} [y/N] `;
+const CONSENT_PROMPT = `Enable anonymous telemetry? Full details at: ${TELEMETRY_DETAILS_URL} [y/yes/N/no] `;
 
 export async function runPostinstall({
   env = process.env, stdin = process.stdin, stdout = process.stdout,
@@ -24,7 +24,7 @@ export async function runPostinstall({
 
     const configPath = defaultTelemetryConfigPath(env);
     const current = readTelemetryConfig(configPath);
-    if (current.prompted_consent_version >= CONSENT_VERSION) return; // never re-ask on reinstall/upgrade
+    if (current.consent_state !== 'unasked') return; // never re-ask on reinstall/upgrade
 
     const rl = readlineFactory();
     let answer;

--- a/packages/sando/src/session-start.mjs
+++ b/packages/sando/src/session-start.mjs
@@ -1,7 +1,8 @@
 import path from 'node:path';
 
 import {
-  closeFinishedDays, defaultTelemetryConfigPath, defaultTelemetryStatePaths, isDoNotTrack, readTelemetryConfig, TELEMETRY_DETAILS_URL,
+  closeFinishedDays, defaultTelemetryConfigPath, defaultTelemetryStatePaths, isDoNotTrack, markTelemetryAsked,
+  readTelemetryConfig, TELEMETRY_DETAILS_URL,
 } from './telemetry.mjs';
 import { PLUGIN_VERSION } from './version.mjs';
 
@@ -10,28 +11,35 @@ export function runSessionStart({
   stdout = process.stdout,
   rootEnv = 'PLUGIN_ROOT',
   spawnImpl,
-  configPath = defaultTelemetryConfigPath(env),
-  statePaths = defaultTelemetryStatePaths(env),
+  configPath,
+  statePaths,
 } = {}) {
   try {
-    const config = readTelemetryConfig(configPath);
-    if (config.enabled && !isDoNotTrack(env)) {
+    if (isDoNotTrack(env)) {
+      stdout.write('{}\n');
+      return;
+    }
+    const telemetryConfigPath = configPath ?? defaultTelemetryConfigPath(env);
+    const telemetryStatePaths = statePaths ?? defaultTelemetryStatePaths(env);
+    const config = readTelemetryConfig(telemetryConfigPath);
+    if (config.enabled) {
       closeFinishedDays({
-        statePaths, configPath, day: new Date().toISOString().slice(0, 10),
+        statePaths: telemetryStatePaths, configPath: telemetryConfigPath, day: new Date().toISOString().slice(0, 10),
         pluginVersion: PLUGIN_VERSION, ...(spawnImpl ? { spawnImpl } : {}),
       });
     }
-    if (isDoNotTrack(env) || config.prompted_consent_version > 0) {
+    if (config.consent_state !== 'unasked' || !markTelemetryAsked(telemetryConfigPath)) {
       stdout.write('{}\n');
       return;
     }
     const pluginRoot = env[rootEnv] || path.resolve(import.meta.dirname, '..');
     const cli = path.join(pluginRoot, 'lib', 'telemetry-cli.mjs');
     stdout.write(`${JSON.stringify({
+      systemMessage: 'Sando can send anonymous aggregate telemetry (opt-in, off by default). '
+        + 'Reply with exactly `sando telemetry yes` or `sando telemetry no`, '
+        + `or run \`node "${cli}" enable\`. Details: ${TELEMETRY_DETAILS_URL}`,
       hookSpecificOutput: {
         hookEventName: 'SessionStart',
-        systemMessage: 'Sando can send anonymous aggregate telemetry (opt-in, off by default). '
-          + `Run \`node "${cli}" enable\` to turn it on. Details: ${TELEMETRY_DETAILS_URL}`,
       },
     })}\n`);
   } catch {

--- a/packages/sando/src/telemetry-cli.mjs
+++ b/packages/sando/src/telemetry-cli.mjs
@@ -10,7 +10,7 @@ import {
 } from './telemetry.mjs';
 
 const USAGE = 'Usage: sando telemetry <status|enable|disable [--purge]|preview|flush>\n';
-const CONSENT_PROMPT = `Enable anonymous telemetry? Full details at: ${TELEMETRY_DETAILS_URL} [y/N] `;
+const CONSENT_PROMPT = `Enable anonymous telemetry? Full details at: ${TELEMETRY_DETAILS_URL} [y/yes/N/no] `;
 
 async function defaultPrompt(message) {
   const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
@@ -47,10 +47,13 @@ export async function runTelemetryCli({
         stdout.write('telemetry already enabled.\n');
         return current;
       }
+      if (current.consent_state === 'declined') {
+        stdout.write('telemetry not enabled.\n');
+        return current;
+      }
       const answer = await prompt(CONSENT_PROMPT);
       const result = enableTelemetry({
-        configPath, interactive: true,
-        answer: /^(y|yes)$/i.test((answer ?? '').trim()) ? 'yes' : answer,
+        configPath, interactive: true, answer,
       });
       stdout.write(result.enabled ? 'telemetry enabled.\n' : 'telemetry not enabled.\n');
       return result;

--- a/packages/sando/src/telemetry.mjs
+++ b/packages/sando/src/telemetry.mjs
@@ -105,6 +105,7 @@ export function serializeEvent(payload) {
 export const TELEMETRY_CONFIG_VERSION = 1;
 export const CONSENT_VERSION = 1;
 export const TELEMETRY_DETAILS_URL = 'https://github.com/yuzushi-dev/Sando/blob/main/TELEMETRY.md';
+export const CONSENT_STATES = ['unasked', 'asked', 'enabled', 'declined'];
 // Canary phase: shared backend, fronted by a Cloudflare Tunnel so it's
 // reachable from any of the owner's machines (see
 // session-handoff/deploy/telemetry/). Rate-limited at nginx (30 req/min/IP).
@@ -119,12 +120,15 @@ export function isDoNotTrack(env = process.env) {
 function record(value) { return value !== null && typeof value === 'object' && !Array.isArray(value); }
 
 function emptyTelemetryConfig() {
-  return { schema_version: TELEMETRY_CONFIG_VERSION, enabled: false, prompted_consent_version: 0 };
+  return {
+    schema_version: TELEMETRY_CONFIG_VERSION, enabled: false, prompted_consent_version: 0, consent_state: 'unasked',
+  };
 }
 
 function validateTelemetryConfig(value) {
   if (!record(value) || value.schema_version !== TELEMETRY_CONFIG_VERSION || typeof value.enabled !== 'boolean'
-    || !Number.isInteger(value.prompted_consent_version) || value.prompted_consent_version < 0) {
+    || !Number.isInteger(value.prompted_consent_version) || value.prompted_consent_version < 0
+    || !CONSENT_STATES.includes(value.consent_state)) {
     throw new Error('telemetry config is invalid');
   }
   if (value.enabled) {
@@ -150,7 +154,14 @@ export function defaultTelemetryStatePaths(env = process.env) {
 
 export function readTelemetryConfig(configPath = defaultTelemetryConfigPath()) {
   if (!fs.existsSync(configPath)) return emptyTelemetryConfig();
-  return validateTelemetryConfig(JSON.parse(fs.readFileSync(configPath, 'utf8')));
+  const value = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+  // Legacy files cannot distinguish an explicit no from blank input or the old
+  // y-as-no bug. Keep that ambiguous decision as asked, not as a decline.
+  const migrated = Object.hasOwn(value, 'consent_state') ? value : {
+    ...value,
+    consent_state: value.enabled ? 'enabled' : value.prompted_consent_version > 0 ? 'asked' : 'unasked',
+  };
+  return validateTelemetryConfig(migrated);
 }
 
 function writeTelemetryConfig(configPath, config) {
@@ -164,19 +175,48 @@ export function statusTelemetry(configPath = defaultTelemetryConfigPath()) {
   return readTelemetryConfig(configPath);
 }
 
-/** Only an explicit `yes` in an interactive session enables collection. */
+export function normalizeConsentAnswer(answer) {
+  if (typeof answer !== 'string') return undefined;
+  const normalized = answer.trim().toLowerCase();
+  if (normalized === 'y' || normalized === 'yes') return 'yes';
+  if (normalized === 'n' || normalized === 'no') return 'no';
+  return undefined;
+}
+
+export function markTelemetryAsked(configPath = defaultTelemetryConfigPath()) {
+  ensureDirectory(path.dirname(configPath));
+  return withLock(`${configPath}.lock`, () => {
+    const current = readTelemetryConfig(configPath);
+    if (current.consent_state !== 'unasked') return false;
+    const next = {
+      ...current, enabled: false, prompted_consent_version: CONSENT_VERSION, consent_state: 'asked',
+    };
+    validateTelemetryConfig(next);
+    atomicWrite(configPath, next);
+    return true;
+  });
+}
+
+/** Only an explicit yes enables collection; explicit no declines, other input stays asked/off. */
 export function enableTelemetry({ configPath = defaultTelemetryConfigPath(), answer, interactive = true, now = () => new Date() } = {}) {
   if (!interactive) return { ...readTelemetryConfig(configPath), exitCode: 1 };
-  if (typeof answer !== 'string' || answer.trim().toLowerCase() !== 'yes') {
-    return writeTelemetryConfig(configPath, { schema_version: TELEMETRY_CONFIG_VERSION, enabled: false, prompted_consent_version: CONSENT_VERSION });
+  const normalized = normalizeConsentAnswer(answer);
+  if (normalized === 'yes') {
+    return writeTelemetryConfig(configPath, {
+      schema_version: TELEMETRY_CONFIG_VERSION,
+      enabled: true,
+      prompted_consent_version: CONSENT_VERSION,
+      consent_state: 'enabled',
+      consent_version: CONSENT_VERSION,
+      consented_at: now().toISOString(),
+      endpoint: TELEMETRY_ENDPOINT,
+    });
   }
   return writeTelemetryConfig(configPath, {
     schema_version: TELEMETRY_CONFIG_VERSION,
-    enabled: true,
+    enabled: false,
     prompted_consent_version: CONSENT_VERSION,
-    consent_version: CONSENT_VERSION,
-    consented_at: now().toISOString(),
-    endpoint: TELEMETRY_ENDPOINT,
+    consent_state: normalized === 'no' ? 'declined' : 'asked',
   });
 }
 
@@ -509,6 +549,7 @@ export function disableTelemetry({ configPath = defaultTelemetryConfigPath(), pu
     schema_version: TELEMETRY_CONFIG_VERSION,
     enabled: false,
     prompted_consent_version: previous.prompted_consent_version || CONSENT_VERSION,
+    consent_state: 'declined',
   });
   if (purge) {
     for (const target of [statePaths.counters, statePaths.queue]) fs.rmSync(target, { force: true });

--- a/packages/sando/src/user-prompt-submit.mjs
+++ b/packages/sando/src/user-prompt-submit.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import {
+  defaultTelemetryConfigPath, enableTelemetry, isDoNotTrack, readTelemetryConfig,
+} from './telemetry.mjs';
+
+const CONSENT_COMMANDS = new Map([
+  ['sando telemetry yes', 'yes'],
+  ['sando telemetry no', 'no'],
+]);
+
+function pass(stdout) { stdout.write('{}\n'); }
+
+export function runUserPromptSubmit({
+  env = process.env, input, stdout = process.stdout, configPath,
+} = {}) {
+  try {
+    if (isDoNotTrack(env)) {
+      pass(stdout);
+      return;
+    }
+    const telemetryConfigPath = configPath ?? defaultTelemetryConfigPath(env);
+    const rawInput = input === undefined ? fs.readFileSync(0, 'utf8') : input;
+    const prompt = JSON.parse(rawInput || '{}').prompt;
+    // Normalizza solo gli spazi ai bordi: non introduce ambiguita' (la stringa
+    // resta esatta) ed evita di perdere risposte genuine incollate con spazi.
+    const answer = typeof prompt === 'string' ? CONSENT_COMMANDS.get(prompt.trim()) : undefined;
+    if (!answer) {
+      pass(stdout);
+      return;
+    }
+    const current = readTelemetryConfig(telemetryConfigPath);
+    if (current.consent_state === 'declined' && answer === 'yes') {
+      pass(stdout);
+      return;
+    }
+    const result = enableTelemetry({ configPath: telemetryConfigPath, interactive: true, answer });
+    stdout.write(`${JSON.stringify({
+      systemMessage: result.enabled ? 'Sando telemetry enabled.' : 'Sando telemetry disabled.',
+    })}\n`);
+  } catch {
+    pass(stdout);
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
+  runUserPromptSubmit();
+}

--- a/packages/sando/tests/bundle-parity.test.mjs
+++ b/packages/sando/tests/bundle-parity.test.mjs
@@ -27,7 +27,7 @@ test('standalone bundles match canonical routing metadata and behavior', async (
 });
 
 test('generated bundle core, routing, session, statusline, and version files match canonical sources', async () => {
-  for (const file of ['core.mjs', 'routing.mjs', 'active-session.mjs', 'statusline.mjs', 'redaction-profile.mjs', 'redaction-config.mjs', 'secret-redaction.mjs', 'provider-usage.mjs', 'telemetry.mjs', 'telemetry-cli.mjs', 'telemetry-flush-entry.mjs', 'session-start.mjs', 'version.mjs']) {
+  for (const file of ['core.mjs', 'routing.mjs', 'active-session.mjs', 'statusline.mjs', 'redaction-profile.mjs', 'redaction-config.mjs', 'secret-redaction.mjs', 'provider-usage.mjs', 'telemetry.mjs', 'telemetry-cli.mjs', 'telemetry-flush-entry.mjs', 'session-start.mjs', 'user-prompt-submit.mjs', 'version.mjs']) {
     const expected = await fs.readFile(path.join(SOURCE, file), 'utf8');
     for (const directory of BUNDLES) assert.equal(await fs.readFile(path.join(directory, file), 'utf8'), expected);
   }

--- a/packages/sando/tests/postinstall.test.mjs
+++ b/packages/sando/tests/postinstall.test.mjs
@@ -82,6 +82,21 @@ test('interactive install with an explicit yes enables telemetry and records the
   });
   assert.match(written, /telemetry enabled/);
   assert.match(prompt, /https:\/\/github\.com\/yuzushi-dev\/Sando\/blob\/main\/TELEMETRY\.md/);
+  assert.match(prompt, /\[y\/yes\/N\/no\]/);
+  assert.equal(readTelemetryConfig(configPath).enabled, true);
+  assert.equal(readTelemetryConfig(configPath).consent_state, 'enabled');
+});
+
+test('interactive install accepts the short yes answer', async () => {
+  const { xdgConfigHome, configPath } = tempConfigPath();
+  const env = { XDG_CONFIG_HOME: xdgConfigHome };
+  const rl = { question: async () => 'y', close: () => {} };
+  await runPostinstall({
+    env,
+    stdin: fakeStream({ isTTY: true }),
+    stdout: { ...fakeStream({ isTTY: true }), write: () => {} },
+    readlineFactory: () => rl,
+  });
   assert.equal(readTelemetryConfig(configPath).enabled, true);
 });
 
@@ -97,6 +112,7 @@ test('declined consent records the disabled marker, not a config write failure',
   });
   assert.equal(readTelemetryConfig(configPath).enabled, false);
   assert.equal(readTelemetryConfig(configPath).prompted_consent_version, 1);
+  assert.equal(readTelemetryConfig(configPath).consent_state, 'declined');
 });
 
 test('a second run never re-prompts once already prompted', async () => {

--- a/packages/sando/tests/telemetry-cli.test.mjs
+++ b/packages/sando/tests/telemetry-cli.test.mjs
@@ -64,7 +64,7 @@ test('enable points to the disclosure instead of printing it inline', async () =
   assert.doesNotMatch(h.output(), /Retention:/);
 });
 
-test('declined consent (blank answer) writes the disabled marker', async () => {
+test('ambiguous consent stays off without recording a decline', async () => {
   const h = harness();
   const result = await runTelemetryCli({
     argv: ['enable'], configPath: h.configPath, stdout: h.stdout, stderr: h.stderr,
@@ -73,6 +73,21 @@ test('declined consent (blank answer) writes the disabled marker', async () => {
   assert.equal(result.enabled, false);
   assert.equal(fs.existsSync(h.configPath), true);
   assert.equal(readTelemetryConfig(h.configPath).enabled, false);
+  assert.equal(readTelemetryConfig(h.configPath).consent_state, 'asked');
+});
+
+test('an explicit CLI enable can resolve an unanswered consent state', async () => {
+  const h = harness();
+  await runTelemetryCli({
+    argv: ['enable'], configPath: h.configPath, stdout: h.stdout, stderr: h.stderr,
+    interactive: true, prompt: async () => 'maybe',
+  });
+  const result = await runTelemetryCli({
+    argv: ['enable'], configPath: h.configPath, stdout: h.stdout, stderr: h.stderr,
+    interactive: true, prompt: async () => 'yes',
+  });
+  assert.equal(result.enabled, true);
+  assert.equal(readTelemetryConfig(h.configPath).consent_state, 'enabled');
 });
 
 test('declined consent ("no") writes the disabled marker', async () => {

--- a/packages/sando/tests/telemetry-consent.test.mjs
+++ b/packages/sando/tests/telemetry-consent.test.mjs
@@ -1,0 +1,177 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import test from 'node:test';
+
+import { runSessionStart } from '../src/session-start.mjs';
+import { runUserPromptSubmit } from '../src/user-prompt-submit.mjs';
+import {
+  CONSENT_VERSION, enableTelemetry, readTelemetryConfig,
+} from '../src/telemetry.mjs';
+
+function harness() {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'sando-consent-'));
+  const env = { XDG_CONFIG_HOME: path.join(directory, 'config') };
+  const configPath = path.join(env.XDG_CONFIG_HOME, 'sando', 'telemetry.json');
+  const statePaths = {
+    counters: path.join(directory, 'state', 'telemetry-counters.json'),
+    queue: path.join(directory, 'state', 'telemetry-queue.jsonl'),
+  };
+  let output = '';
+  return {
+    directory, env, configPath, statePaths,
+    stdout: { write: (chunk) => { output += chunk; } },
+    output: () => output,
+  };
+}
+
+test('SessionStart stores asked before emitting a top-level systemMessage', () => {
+  const h = harness();
+  runSessionStart({ env: h.env, configPath: h.configPath, statePaths: h.statePaths, stdout: h.stdout, rootEnv: 'PLUGIN_ROOT' });
+
+  const payload = JSON.parse(h.output());
+  assert.equal(typeof payload.systemMessage, 'string');
+  assert.equal(payload.hookSpecificOutput.hookEventName, 'SessionStart');
+  assert.equal(Object.hasOwn(payload.hookSpecificOutput, 'systemMessage'), false);
+  assert.match(payload.systemMessage, /sando telemetry yes/);
+  assert.match(payload.systemMessage, /sando telemetry no/);
+  assert.equal(readTelemetryConfig(h.configPath).consent_state, 'asked');
+  assert.equal(readTelemetryConfig(h.configPath).prompted_consent_version, CONSENT_VERSION);
+});
+
+test('SessionStart emits no question when the asked transition cannot be persisted', () => {
+  const h = harness();
+  const blocker = path.join(h.directory, 'not-a-directory');
+  fs.writeFileSync(blocker, 'block');
+  const output = [];
+  runSessionStart({
+    env: h.env,
+    configPath: path.join(blocker, 'telemetry.json'),
+    statePaths: h.statePaths,
+    stdout: { write: (chunk) => output.push(chunk) },
+  });
+  assert.deepEqual(JSON.parse(output.join('')), {});
+});
+
+test('consent normalization accepts y/yes and n/no case-insensitively', () => {
+  for (const answer of ['y', 'yes', 'Y', 'YES']) {
+    const h = harness();
+    const result = enableTelemetry({ configPath: h.configPath, answer, interactive: true });
+    assert.equal(result.enabled, true, answer);
+    assert.equal(readTelemetryConfig(h.configPath).consent_state, 'enabled', answer);
+  }
+  for (const answer of ['n', 'no', 'N', 'NO']) {
+    const h = harness();
+    const result = enableTelemetry({ configPath: h.configPath, answer, interactive: true });
+    assert.equal(result.enabled, false, answer);
+    assert.equal(readTelemetryConfig(h.configPath).consent_state, 'declined', answer);
+  }
+});
+
+test('blank or ambiguous consent stays off without recording a decline', () => {
+  for (const answer of ['', 'maybe', undefined]) {
+    const h = harness();
+    const result = enableTelemetry({ configPath: h.configPath, answer, interactive: true });
+    assert.equal(result.enabled, false, String(answer));
+    assert.equal(readTelemetryConfig(h.configPath).consent_state, 'asked', String(answer));
+  }
+});
+
+test('legacy disabled consent markers remain recoverable as asked', () => {
+  const h = harness();
+  fs.mkdirSync(path.dirname(h.configPath), { recursive: true });
+  fs.writeFileSync(h.configPath, JSON.stringify({ schema_version: 1, enabled: false, prompted_consent_version: 1 }));
+  const output = [];
+  runUserPromptSubmit({
+    env: h.env,
+    input: JSON.stringify({ prompt: 'sando telemetry yes' }),
+    stdout: { write: (chunk) => output.push(chunk) },
+  });
+  assert.equal(readTelemetryConfig(h.configPath).enabled, true);
+  assert.match(JSON.parse(output.join('')).systemMessage, /enabled/i);
+});
+
+test('an ambiguous answer leaves the one-time question answered but not declined', () => {
+  const h = harness();
+  enableTelemetry({ configPath: h.configPath, answer: 'maybe', interactive: true });
+  const output = [];
+  runSessionStart({ env: h.env, configPath: h.configPath, statePaths: h.statePaths, stdout: { write: (chunk) => output.push(chunk) } });
+  assert.deepEqual(JSON.parse(output.join('')), {});
+  assert.equal(readTelemetryConfig(h.configPath).consent_state, 'asked');
+});
+
+test('UserPromptSubmit accepts only the two exact chat commands and passes everything else through', () => {
+  const h = harness();
+  const output = [];
+  runUserPromptSubmit({
+    env: h.env,
+    input: JSON.stringify({ prompt: 'sando telemetry yes please' }),
+    stdout: { write: (chunk) => output.push(chunk) },
+  });
+  assert.deepEqual(JSON.parse(output.join('')), {});
+  assert.equal(fs.existsSync(h.configPath), false);
+});
+
+test('UserPromptSubmit records an exact yes without blocking the prompt', () => {
+  const h = harness();
+  runSessionStart({ env: h.env, configPath: h.configPath, statePaths: h.statePaths, stdout: { write() {} } });
+  const output = [];
+  runUserPromptSubmit({
+    env: h.env,
+    input: JSON.stringify({ prompt: 'sando telemetry yes' }),
+    stdout: { write: (chunk) => output.push(chunk) },
+  });
+  const payload = JSON.parse(output.join(''));
+  assert.match(payload.systemMessage, /enabled/i);
+  assert.equal(Object.hasOwn(payload, 'decision'), false);
+  assert.equal(Object.hasOwn(payload, 'additionalContext'), false);
+  assert.equal(readTelemetryConfig(h.configPath).consent_state, 'enabled');
+});
+
+test('UserPromptSubmit records an exact no as a decline', () => {
+  const h = harness();
+  runSessionStart({ env: h.env, configPath: h.configPath, statePaths: h.statePaths, stdout: { write() {} } });
+  const output = [];
+  runUserPromptSubmit({
+    env: h.env,
+    input: JSON.stringify({ prompt: 'sando telemetry no' }),
+    stdout: { write: (chunk) => output.push(chunk) },
+  });
+  const payload = JSON.parse(output.join(''));
+  assert.match(payload.systemMessage, /disabled/i);
+  assert.equal(readTelemetryConfig(h.configPath).consent_state, 'declined');
+});
+
+test('UserPromptSubmit obeys DO_NOT_TRACK', () => {
+  const h = harness();
+  runSessionStart({ env: h.env, configPath: h.configPath, statePaths: h.statePaths, stdout: { write() {} } });
+  const output = [];
+  runUserPromptSubmit({
+    env: { ...h.env, DO_NOT_TRACK: '1' },
+    input: JSON.stringify({ prompt: 'sando telemetry no' }),
+    stdout: { write: (chunk) => output.push(chunk) },
+  });
+  assert.deepEqual(JSON.parse(output.join('')), {});
+  assert.equal(readTelemetryConfig(h.configPath).consent_state, 'asked');
+});
+
+test('installed Claude and plugin UserPromptSubmit wrappers preserve the fail-open contract', () => {
+  const root = path.resolve(import.meta.dirname, '../../..');
+  for (const bundle of ['adapters/claude/sando', 'plugins/sando']) {
+    const h = harness();
+    const environment = { ...process.env, ...h.env };
+    const start = spawnSync(process.execPath, [path.join(root, bundle, 'hooks/session-start.mjs')], {
+      encoding: 'utf8', env: environment,
+    });
+    assert.equal(start.status, 0, start.stderr);
+    assert.equal(typeof JSON.parse(start.stdout).systemMessage, 'string');
+    const response = spawnSync(process.execPath, [path.join(root, bundle, 'hooks/user-prompt-submit.mjs')], {
+      input: JSON.stringify({ prompt: 'sando telemetry maybe' }), encoding: 'utf8', env: environment,
+    });
+    assert.equal(response.status, 0, response.stderr);
+    assert.deepEqual(JSON.parse(response.stdout), {});
+    assert.equal(readTelemetryConfig(h.configPath).consent_state, 'asked');
+  }
+});

--- a/plugins/sando/hooks/hooks.json
+++ b/plugins/sando/hooks/hooks.json
@@ -12,6 +12,17 @@
         ]
       }
     ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${PLUGIN_ROOT}/hooks/user-prompt-submit.mjs\"",
+            "timeout": 1
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "^(Bash|exec_command|shell_command)$",

--- a/plugins/sando/hooks/user-prompt-submit.mjs
+++ b/plugins/sando/hooks/user-prompt-submit.mjs
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+import { runUserPromptSubmit } from '../lib/user-prompt-submit.mjs';
+
+runUserPromptSubmit();

--- a/plugins/sando/lib/session-start.mjs
+++ b/plugins/sando/lib/session-start.mjs
@@ -1,7 +1,8 @@
 import path from 'node:path';
 
 import {
-  closeFinishedDays, defaultTelemetryConfigPath, defaultTelemetryStatePaths, isDoNotTrack, readTelemetryConfig, TELEMETRY_DETAILS_URL,
+  closeFinishedDays, defaultTelemetryConfigPath, defaultTelemetryStatePaths, isDoNotTrack, markTelemetryAsked,
+  readTelemetryConfig, TELEMETRY_DETAILS_URL,
 } from './telemetry.mjs';
 import { PLUGIN_VERSION } from './version.mjs';
 
@@ -10,28 +11,35 @@ export function runSessionStart({
   stdout = process.stdout,
   rootEnv = 'PLUGIN_ROOT',
   spawnImpl,
-  configPath = defaultTelemetryConfigPath(env),
-  statePaths = defaultTelemetryStatePaths(env),
+  configPath,
+  statePaths,
 } = {}) {
   try {
-    const config = readTelemetryConfig(configPath);
-    if (config.enabled && !isDoNotTrack(env)) {
+    if (isDoNotTrack(env)) {
+      stdout.write('{}\n');
+      return;
+    }
+    const telemetryConfigPath = configPath ?? defaultTelemetryConfigPath(env);
+    const telemetryStatePaths = statePaths ?? defaultTelemetryStatePaths(env);
+    const config = readTelemetryConfig(telemetryConfigPath);
+    if (config.enabled) {
       closeFinishedDays({
-        statePaths, configPath, day: new Date().toISOString().slice(0, 10),
+        statePaths: telemetryStatePaths, configPath: telemetryConfigPath, day: new Date().toISOString().slice(0, 10),
         pluginVersion: PLUGIN_VERSION, ...(spawnImpl ? { spawnImpl } : {}),
       });
     }
-    if (isDoNotTrack(env) || config.prompted_consent_version > 0) {
+    if (config.consent_state !== 'unasked' || !markTelemetryAsked(telemetryConfigPath)) {
       stdout.write('{}\n');
       return;
     }
     const pluginRoot = env[rootEnv] || path.resolve(import.meta.dirname, '..');
     const cli = path.join(pluginRoot, 'lib', 'telemetry-cli.mjs');
     stdout.write(`${JSON.stringify({
+      systemMessage: 'Sando can send anonymous aggregate telemetry (opt-in, off by default). '
+        + 'Reply with exactly `sando telemetry yes` or `sando telemetry no`, '
+        + `or run \`node "${cli}" enable\`. Details: ${TELEMETRY_DETAILS_URL}`,
       hookSpecificOutput: {
         hookEventName: 'SessionStart',
-        systemMessage: 'Sando can send anonymous aggregate telemetry (opt-in, off by default). '
-          + `Run \`node "${cli}" enable\` to turn it on. Details: ${TELEMETRY_DETAILS_URL}`,
       },
     })}\n`);
   } catch {

--- a/plugins/sando/lib/telemetry-cli.mjs
+++ b/plugins/sando/lib/telemetry-cli.mjs
@@ -10,7 +10,7 @@ import {
 } from './telemetry.mjs';
 
 const USAGE = 'Usage: sando telemetry <status|enable|disable [--purge]|preview|flush>\n';
-const CONSENT_PROMPT = `Enable anonymous telemetry? Full details at: ${TELEMETRY_DETAILS_URL} [y/N] `;
+const CONSENT_PROMPT = `Enable anonymous telemetry? Full details at: ${TELEMETRY_DETAILS_URL} [y/yes/N/no] `;
 
 async function defaultPrompt(message) {
   const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
@@ -47,10 +47,13 @@ export async function runTelemetryCli({
         stdout.write('telemetry already enabled.\n');
         return current;
       }
+      if (current.consent_state === 'declined') {
+        stdout.write('telemetry not enabled.\n');
+        return current;
+      }
       const answer = await prompt(CONSENT_PROMPT);
       const result = enableTelemetry({
-        configPath, interactive: true,
-        answer: /^(y|yes)$/i.test((answer ?? '').trim()) ? 'yes' : answer,
+        configPath, interactive: true, answer,
       });
       stdout.write(result.enabled ? 'telemetry enabled.\n' : 'telemetry not enabled.\n');
       return result;

--- a/plugins/sando/lib/telemetry.mjs
+++ b/plugins/sando/lib/telemetry.mjs
@@ -105,6 +105,7 @@ export function serializeEvent(payload) {
 export const TELEMETRY_CONFIG_VERSION = 1;
 export const CONSENT_VERSION = 1;
 export const TELEMETRY_DETAILS_URL = 'https://github.com/yuzushi-dev/Sando/blob/main/TELEMETRY.md';
+export const CONSENT_STATES = ['unasked', 'asked', 'enabled', 'declined'];
 // Canary phase: shared backend, fronted by a Cloudflare Tunnel so it's
 // reachable from any of the owner's machines (see
 // session-handoff/deploy/telemetry/). Rate-limited at nginx (30 req/min/IP).
@@ -119,12 +120,15 @@ export function isDoNotTrack(env = process.env) {
 function record(value) { return value !== null && typeof value === 'object' && !Array.isArray(value); }
 
 function emptyTelemetryConfig() {
-  return { schema_version: TELEMETRY_CONFIG_VERSION, enabled: false, prompted_consent_version: 0 };
+  return {
+    schema_version: TELEMETRY_CONFIG_VERSION, enabled: false, prompted_consent_version: 0, consent_state: 'unasked',
+  };
 }
 
 function validateTelemetryConfig(value) {
   if (!record(value) || value.schema_version !== TELEMETRY_CONFIG_VERSION || typeof value.enabled !== 'boolean'
-    || !Number.isInteger(value.prompted_consent_version) || value.prompted_consent_version < 0) {
+    || !Number.isInteger(value.prompted_consent_version) || value.prompted_consent_version < 0
+    || !CONSENT_STATES.includes(value.consent_state)) {
     throw new Error('telemetry config is invalid');
   }
   if (value.enabled) {
@@ -150,7 +154,14 @@ export function defaultTelemetryStatePaths(env = process.env) {
 
 export function readTelemetryConfig(configPath = defaultTelemetryConfigPath()) {
   if (!fs.existsSync(configPath)) return emptyTelemetryConfig();
-  return validateTelemetryConfig(JSON.parse(fs.readFileSync(configPath, 'utf8')));
+  const value = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+  // Legacy files cannot distinguish an explicit no from blank input or the old
+  // y-as-no bug. Keep that ambiguous decision as asked, not as a decline.
+  const migrated = Object.hasOwn(value, 'consent_state') ? value : {
+    ...value,
+    consent_state: value.enabled ? 'enabled' : value.prompted_consent_version > 0 ? 'asked' : 'unasked',
+  };
+  return validateTelemetryConfig(migrated);
 }
 
 function writeTelemetryConfig(configPath, config) {
@@ -164,19 +175,48 @@ export function statusTelemetry(configPath = defaultTelemetryConfigPath()) {
   return readTelemetryConfig(configPath);
 }
 
-/** Only an explicit `yes` in an interactive session enables collection. */
+export function normalizeConsentAnswer(answer) {
+  if (typeof answer !== 'string') return undefined;
+  const normalized = answer.trim().toLowerCase();
+  if (normalized === 'y' || normalized === 'yes') return 'yes';
+  if (normalized === 'n' || normalized === 'no') return 'no';
+  return undefined;
+}
+
+export function markTelemetryAsked(configPath = defaultTelemetryConfigPath()) {
+  ensureDirectory(path.dirname(configPath));
+  return withLock(`${configPath}.lock`, () => {
+    const current = readTelemetryConfig(configPath);
+    if (current.consent_state !== 'unasked') return false;
+    const next = {
+      ...current, enabled: false, prompted_consent_version: CONSENT_VERSION, consent_state: 'asked',
+    };
+    validateTelemetryConfig(next);
+    atomicWrite(configPath, next);
+    return true;
+  });
+}
+
+/** Only an explicit yes enables collection; explicit no declines, other input stays asked/off. */
 export function enableTelemetry({ configPath = defaultTelemetryConfigPath(), answer, interactive = true, now = () => new Date() } = {}) {
   if (!interactive) return { ...readTelemetryConfig(configPath), exitCode: 1 };
-  if (typeof answer !== 'string' || answer.trim().toLowerCase() !== 'yes') {
-    return writeTelemetryConfig(configPath, { schema_version: TELEMETRY_CONFIG_VERSION, enabled: false, prompted_consent_version: CONSENT_VERSION });
+  const normalized = normalizeConsentAnswer(answer);
+  if (normalized === 'yes') {
+    return writeTelemetryConfig(configPath, {
+      schema_version: TELEMETRY_CONFIG_VERSION,
+      enabled: true,
+      prompted_consent_version: CONSENT_VERSION,
+      consent_state: 'enabled',
+      consent_version: CONSENT_VERSION,
+      consented_at: now().toISOString(),
+      endpoint: TELEMETRY_ENDPOINT,
+    });
   }
   return writeTelemetryConfig(configPath, {
     schema_version: TELEMETRY_CONFIG_VERSION,
-    enabled: true,
+    enabled: false,
     prompted_consent_version: CONSENT_VERSION,
-    consent_version: CONSENT_VERSION,
-    consented_at: now().toISOString(),
-    endpoint: TELEMETRY_ENDPOINT,
+    consent_state: normalized === 'no' ? 'declined' : 'asked',
   });
 }
 
@@ -509,6 +549,7 @@ export function disableTelemetry({ configPath = defaultTelemetryConfigPath(), pu
     schema_version: TELEMETRY_CONFIG_VERSION,
     enabled: false,
     prompted_consent_version: previous.prompted_consent_version || CONSENT_VERSION,
+    consent_state: 'declined',
   });
   if (purge) {
     for (const target of [statePaths.counters, statePaths.queue]) fs.rmSync(target, { force: true });

--- a/plugins/sando/lib/user-prompt-submit.mjs
+++ b/plugins/sando/lib/user-prompt-submit.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import {
+  defaultTelemetryConfigPath, enableTelemetry, isDoNotTrack, readTelemetryConfig,
+} from './telemetry.mjs';
+
+const CONSENT_COMMANDS = new Map([
+  ['sando telemetry yes', 'yes'],
+  ['sando telemetry no', 'no'],
+]);
+
+function pass(stdout) { stdout.write('{}\n'); }
+
+export function runUserPromptSubmit({
+  env = process.env, input, stdout = process.stdout, configPath,
+} = {}) {
+  try {
+    if (isDoNotTrack(env)) {
+      pass(stdout);
+      return;
+    }
+    const telemetryConfigPath = configPath ?? defaultTelemetryConfigPath(env);
+    const rawInput = input === undefined ? fs.readFileSync(0, 'utf8') : input;
+    const prompt = JSON.parse(rawInput || '{}').prompt;
+    // Normalizza solo gli spazi ai bordi: non introduce ambiguita' (la stringa
+    // resta esatta) ed evita di perdere risposte genuine incollate con spazi.
+    const answer = typeof prompt === 'string' ? CONSENT_COMMANDS.get(prompt.trim()) : undefined;
+    if (!answer) {
+      pass(stdout);
+      return;
+    }
+    const current = readTelemetryConfig(telemetryConfigPath);
+    if (current.consent_state === 'declined' && answer === 'yes') {
+      pass(stdout);
+      return;
+    }
+    const result = enableTelemetry({ configPath: telemetryConfigPath, interactive: true, answer });
+    stdout.write(`${JSON.stringify({
+      systemMessage: result.enabled ? 'Sando telemetry enabled.' : 'Sando telemetry disabled.',
+    })}\n`);
+  } catch {
+    pass(stdout);
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
+  runUserPromptSubmit();
+}

--- a/scripts/sync-bundles.mjs
+++ b/scripts/sync-bundles.mjs
@@ -10,7 +10,7 @@ const bundles = [
 ];
 
 for (const directory of bundles) {
-  for (const file of ['core.mjs', 'routing.mjs', 'active-session.mjs', 'statusline.mjs', 'redaction-profile.mjs', 'redaction-config.mjs', 'secret-redaction.mjs', 'provider-usage.mjs', 'telemetry.mjs', 'telemetry-cli.mjs', 'telemetry-flush-entry.mjs', 'session-start.mjs', 'version.mjs']) {
+  for (const file of ['core.mjs', 'routing.mjs', 'active-session.mjs', 'statusline.mjs', 'redaction-profile.mjs', 'redaction-config.mjs', 'secret-redaction.mjs', 'provider-usage.mjs', 'telemetry.mjs', 'telemetry-cli.mjs', 'telemetry-flush-entry.mjs', 'session-start.mjs', 'user-prompt-submit.mjs', 'version.mjs']) {
     await fs.copyFile(path.join(source, file), path.join(root, directory, file));
   }
 }


### PR DESCRIPTION
Tre difetti rendevano inefficace, o dannosa, la richiesta di consenso alla telemetria.

## 1. La notifica non e' mai stata mostrata a nessuno

`systemMessage` era annidato dentro `hookSpecificOutput`, dove il client non lo legge. Per il [contratto degli hook](https://code.claude.com/docs/en/hooks) e' un campo **universale top-level**; `hookSpecificOutput` per SessionStart accetta solo `additionalContext`, `initialUserMessage`, `sessionTitle`, `watchPaths`, `reloadSkills`.

Il lavoro sulla raggiungibilita' del consenso era quindi inefficace dal primo giorno. I test verificavano il JSON prodotto ma non la **posizione** del campo, quindi passavano su codice che non funzionava: ora asseriscono che sia top-level e assente dall'oggetto annidato.

## 2. Chi rispondeva `y` veniva registrato come contrario, per sempre

Il prompt diceva `[y/N]` ma il codice accettava solo `yes`. Verificato empiricamente:

```
risposta "y"   -> enabled=False    e il rifiuto e' definitivo
risposta "yes" -> enabled=True
```

Poiche' il rifiuto consuma lo stato "gia' chiesto", a quell'utente non sarebbe mai piu' stato chiesto nulla. Ora `y`, `yes`, `n`, `no` sono accettati senza distinzione di maiuscole, e una risposta vuota o ambigua lascia la telemetria spenta **senza** registrare un rifiuto esplicito che non c'e' stato.

## 3. Acconsentire richiedeva di aprire un terminale

Un hook `UserPromptSubmit` riconosce ora la risposta scritta direttamente in chat.

Il confronto e' sulla **stringa esatta**, con i soli spazi ai bordi normalizzati. Una frase che contiene il comando non vale come risposta:

```
"session-handoff telemetry yes"                -> riconosciuto
"  session-handoff telemetry yes  "            -> riconosciuto
"come si fa session-handoff telemetry yes?"    -> ignorato
"yes"                                          -> ignorato
```

L'hook sta nel percorso di ogni messaggio dell'utente: non fa rete, e su input malformato esce `0` lasciando passare il prompt inalterato (verificato su JSON non valido, vuoto, e `prompt: null`).

## Stato del consenso

Diventa esplicito — `unasked -> asked -> enabled|declined` — invece di essere dedotto da `prompted_consent_version`. `DO_NOT_TRACK` e' verificato prima di qualsiasi scrittura.

Flusso verificato end-to-end: prima sessione mostra la domanda e registra `asked`; la risposta in chat porta a `enabled`; la sessione successiva non ripete la domanda.

## Informativa

Non rimanda piu' a percorsi locali `~/selfhosted/...` che l'utente non puo' aprire. Le verifiche ancora aperte (canary, privacy review indipendente) restano dichiarate come tali.

## Cosa e' stato escluso, e perche'

- **MCP elicitation**: conversione piu' alta, ma sospende il primo prompt dell'utente.
- **Far porre la domanda all'assistente** via `additionalContext`: userebbe l'autorita' del contesto del modello per un interesse del maintainer, con un'istruzione invisibile all'utente, e non sarebbe verificabile quale informativa sia stata realmente mostrata.

Il "no" resta esattamente facile quanto il "si'": l'obiettivo e' che le persone **rispondano**, non che dicano di si'.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
