### PR TITLE
Rilascia 0.3.0: richiesta di consenso in chat

### DIFF
--- a/adapters/claude/sando/.claude-plugin/marketplace.json
+++ b/adapters/claude/sando/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   "plugins": [
     {
       "name": "sando",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "source": "./",
       "description": "Reduce repeated tool-output context in Claude Code."
     }

--- a/adapters/claude/sando/.claude-plugin/plugin.json
+++ b/adapters/claude/sando/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sando",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Reduce repeated tool-output context in Claude Code.",
   "author": {
     "name": "Sando contributors"

--- a/adapters/claude/sando/lib/version.mjs
+++ b/adapters/claude/sando/lib/version.mjs
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 const VERSION_PATTERN = /^\d+\.\d+(?:\.\d+)?$/;
-const STANDALONE_VERSION = '0.2.0';
+const STANDALONE_VERSION = '0.3.0';
 const METADATA_FILES = ['package.json', '.claude-plugin/plugin.json', '.codex-plugin/plugin.json'];
 
 function findMetadataFile() {

--- a/adapters/codex/sando/lib/version.mjs
+++ b/adapters/codex/sando/lib/version.mjs
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 const VERSION_PATTERN = /^\d+\.\d+(?:\.\d+)?$/;
-const STANDALONE_VERSION = '0.2.0';
+const STANDALONE_VERSION = '0.3.0';
 const METADATA_FILES = ['package.json', '.claude-plugin/plugin.json', '.codex-plugin/plugin.json'];
 
 function findMetadataFile() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sando",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "engines": {

--- a/packages/sando/package.json
+++ b/packages/sando/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandoichi",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Reduce repeated tool-output context in Claude Code and Codex.",
   "license": "MIT",
   "author": "yuzushi",

--- a/packages/sando/src/version.mjs
+++ b/packages/sando/src/version.mjs
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 const VERSION_PATTERN = /^\d+\.\d+(?:\.\d+)?$/;
-const STANDALONE_VERSION = '0.2.0';
+const STANDALONE_VERSION = '0.3.0';
 const METADATA_FILES = ['package.json', '.claude-plugin/plugin.json', '.codex-plugin/plugin.json'];
 
 function findMetadataFile() {

--- a/plugins/sando/.agents/plugins/marketplace.json
+++ b/plugins/sando/.agents/plugins/marketplace.json
@@ -3,7 +3,7 @@
   "interface": { "displayName": "Sando" },
   "metadata": {
     "description": "Reduce repeated tool-output context in Codex.",
-    "version": "0.2.0"
+    "version": "0.3.0"
   },
   "plugins": [
     {

--- a/plugins/sando/.codex-plugin/plugin.json
+++ b/plugins/sando/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sando",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Reduce repeated tool-output context in Codex.",
   "author": {
     "name": "Sando contributors"

--- a/plugins/sando/lib/version.mjs
+++ b/plugins/sando/lib/version.mjs
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 const VERSION_PATTERN = /^\d+\.\d+(?:\.\d+)?$/;
-const STANDALONE_VERSION = '0.2.0';
+const STANDALONE_VERSION = '0.3.0';
 const METADATA_FILES = ['package.json', '.claude-plugin/plugin.json', '.codex-plugin/plugin.json'];
 
 function findMetadataFile() {


### PR DESCRIPTION
Rilascia [#2](https://github.com/yuzushi-dev/Sando/pull/2): hook `UserPromptSubmit` per rispondere al consenso in chat, più le correzioni di `systemMessage` annidato, `y` trattato come rifiuto definitivo dal percorso postinstall, e informativa non autosufficiente.

Minor e non patch: il nuovo hook è funzionalità aggiuntiva e modifica il manifest degli hook dichiarati dal plugin.

Versione risolta a runtime dal bundle: `0.3.0`. Suite: `445 passed, 0 failed` (254 package + 142 benchmark + 49 bundle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)