### PR TITLE
Release Sando 0.4.0

### DIFF
--- a/adapters/claude/sando/.claude-plugin/marketplace.json
+++ b/adapters/claude/sando/.claude-plugin/marketplace.json
@@ -1,13 +1,13 @@
 {
   "name": "sando-local",
   "owner": { "name": "Sando contributors" },
-  "metadata": { "description": "Sando local Claude Code plugin" },
+  "metadata": { "description": "Sando local Claude Code plugin with provider accounting" },
   "plugins": [
     {
       "name": "sando",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "source": "./",
-      "description": "Reduce repeated tool-output context in Claude Code."
+      "description": "Bound repeated tool-output context in Claude Code with deterministic hooks and provider accounting."
     }
   ]
 }

--- a/adapters/claude/sando/.claude-plugin/plugin.json
+++ b/adapters/claude/sando/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sando",
-  "version": "0.3.0",
-  "description": "Reduce repeated tool-output context in Claude Code.",
+  "version": "0.4.0",
+  "description": "Bound repeated tool-output context in Claude Code with deterministic hooks and provider accounting.",
   "author": {
     "name": "Sando contributors"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sando",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "type": "module",
   "engines": {

--- a/packages/sando/package.json
+++ b/packages/sando/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sandoichi",
-  "version": "0.3.0",
-  "description": "Reduce repeated tool-output context in Claude Code and Codex.",
+  "version": "0.4.0",
+  "description": "Bound repeated tool-output context in Claude Code and Codex with deterministic local routing and provider accounting.",
   "license": "MIT",
   "author": "yuzushi",
   "repository": {

--- a/plugins/sando/.agents/plugins/marketplace.json
+++ b/plugins/sando/.agents/plugins/marketplace.json
@@ -2,13 +2,13 @@
   "name": "sando-local",
   "interface": { "displayName": "Sando" },
   "metadata": {
-    "description": "Reduce repeated tool-output context in Codex.",
-    "version": "0.3.0"
+    "description": "Bound repeated tool-output context in Codex with deterministic local routing and provider accounting.",
+    "version": "0.4.0"
   },
   "plugins": [
     {
       "name": "sando",
-      "description": "Reduce repeated tool-output context in Codex.",
+      "description": "Bound repeated tool-output context in Codex with deterministic local routing and provider accounting.",
       "source": { "source": "local", "path": "./" },
       "policy": { "installation": "AVAILABLE" },
       "category": "Developer Tools",

--- a/plugins/sando/.codex-plugin/plugin.json
+++ b/plugins/sando/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sando",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Bound repeated tool-output context in Codex with deterministic local routing and provider accounting.",
   "author": {
     "name": "Sando contributors"


### PR DESCRIPTION
Release metadata for the merged provider-accounting and paired-control tranche. Aligns root/package/plugin/local marketplace versions to 0.4.0 and updates host-specific descriptions. Verification: npm test; npm run check; python3 -m unittest scripts/test_weekly_report.py; git diff --check.